### PR TITLE
Configure base path from Pages metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -31,6 +35,8 @@ jobs:
         run: npm ci
 
       - name: Build project
+        env:
+          BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: npm run build
 
       - name: Upload build artifact

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,9 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const configuredBase = process.env.BASE_PATH;
 const repository = process.env.GITHUB_REPOSITORY ?? "";
-const base = repository ? `/${repository.split("/").pop()}/` : "/";
+const base = configuredBase ?? (repository ? `/${repository.split("/").pop()}/` : "/");
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- configure Vite to honor a BASE_PATH environment variable when determining the build base URL
- update the Pages deployment workflow to derive BASE_PATH from actions/configure-pages so custom domains serve assets correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d6070e80832c912b3b3f09214f53