### PR TITLE
Set VITE_CONVEX_URL for GitHub Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build project
         env:
           BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          VITE_CONVEX_URL: https://knowing-bass-400.convex.cloud
         run: npm run build
 
       - name: Upload build artifact


### PR DESCRIPTION
## Summary
- expose the Convex deployment URL to the build job so Vite can use it during compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d885b93500832ca9104695e75fc706