### PR TITLE
Fix Playwright signup flow to run from login page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.55.1",
         "@types/lodash": "^4.17.20",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
@@ -1358,6 +1359,22 @@
         "reflect-metadata": "^0.2.2",
         "tslib": "^2.8.1",
         "tsyringe": "^4.10.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5335,6 +5352,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.55.1",
     "@types/lodash": "^4.17.20",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const CONVEX_URL = process.env.VITE_CONVEX_URL ?? 'http://127.0.0.1:3999';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list'], ...(process.env.CI ? [['github']] : [])],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT}`,
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    env: {
+      ...process.env,
+      VITE_CONVEX_URL: CONVEX_URL,
+    },
+  },
+});

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,219 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { jsonToConvex } from 'convex/values';
+
+type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+  status: string;
+};
+
+type ConvexCall = Record<string, any>;
+
+type ConvexMocks = {
+  signUpCalls: ConvexCall[];
+  signInCalls: ConvexCall[];
+  validateSessionCalls: ConvexCall[];
+  getCurrentUser: () => AuthUser;
+};
+
+const baseUser: AuthUser = {
+  id: 'user_1',
+  email: 'test.user@example.com',
+  name: 'Test User',
+  role: 'owner',
+  companyId: 'company_1',
+  status: 'active',
+};
+
+const convexSuccessResponse = (value: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify({
+    status: 'success',
+    value,
+    logLines: [],
+  }),
+});
+
+const decodeConvexRequest = (route: Route) => {
+  const bodyText = route.request().postData() ?? '{}';
+  const body = JSON.parse(bodyText) as {
+    path?: string;
+    args?: unknown[];
+  };
+  const [encodedArgs] = body.args ?? [];
+  const decodedArgs = encodedArgs
+    ? (jsonToConvex(encodedArgs as any) as Record<string, any>)
+    : {};
+  return { path: body.path, args: decodedArgs };
+};
+
+const setupConvexMocks = async (
+  page: Page,
+  options: { user?: Partial<AuthUser> } = {},
+): Promise<ConvexMocks> => {
+  const signUpCalls: ConvexCall[] = [];
+  const signInCalls: ConvexCall[] = [];
+  const validateSessionCalls: ConvexCall[] = [];
+
+  let activeToken: string | null = null;
+  let currentUser: AuthUser = { ...baseUser, ...options.user };
+
+  const respond = (route: Route, value: unknown) =>
+    route.fulfill(convexSuccessResponse(value));
+
+  await page.route('**/api/query_ts', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ts: Date.now().toString() }),
+    }),
+  );
+
+  const handleQuery = (route: Route) => {
+    const { path } = decodeConvexRequest(route);
+    if (path?.startsWith('admin:')) {
+      return respond(route, { data: [], total: 0 });
+    }
+    return respond(route, null);
+  };
+
+  await page.route('**/api/query', handleQuery);
+  await page.route('**/api/query_at_ts', handleQuery);
+
+  await page.route('**/api/mutation', (route) => respond(route, {}));
+
+  await page.route('**/api/action', (route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === 'auth:signUp') {
+      signUpCalls.push(args);
+      currentUser = {
+        ...currentUser,
+        id: 'user_signup',
+        email: args.email,
+        name: args.name ?? currentUser.name,
+        role: 'owner',
+      };
+      activeToken = 'test-signup-token';
+      return respond(route, { token: activeToken, user: currentUser });
+    }
+
+    if (path === 'auth:signIn') {
+      signInCalls.push(args);
+      currentUser = {
+        ...currentUser,
+        email: args.email,
+      };
+      activeToken = 'test-session-token';
+      return respond(route, { token: activeToken, user: currentUser });
+    }
+
+    if (path === 'auth:validateSession') {
+      validateSessionCalls.push(args);
+      if (!activeToken) {
+        return respond(route, null);
+      }
+      const now = new Date();
+      return respond(route, {
+        session: {
+          token: activeToken,
+          userId: currentUser.id,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          expiresAt: new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString(),
+        },
+        user: currentUser,
+      });
+    }
+
+    return respond(route, {});
+  });
+
+  return {
+    signUpCalls,
+    signInCalls,
+    validateSessionCalls,
+    getCurrentUser: () => currentUser,
+  };
+};
+
+test.describe('Authentication flows', () => {
+  test('allows a new owner to sign up and sign in', async ({ page }) => {
+    const mocks = await setupConvexMocks(page);
+
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+
+    const openSignUp = page.getByRole('button', { name: /create one/i });
+    await expect(openSignUp).toBeVisible();
+    await openSignUp.click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: /create an account/i }),
+    ).toBeVisible();
+
+    const nameField = page.getByPlaceholder('Jane Doe');
+    await expect(nameField).toBeVisible();
+    await nameField.fill('New Owner');
+    await page.getByLabel('Email').fill('New.Owner@Example.com');
+    await page.getByLabel('Company Name').fill('HavenHost');
+    await page.getByLabel('Password').fill('Sup3rSecret!');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await expect(
+      page.getByRole('heading', { level: 2, name: /companies/i }),
+    ).toBeVisible();
+
+    await expect.poll(() =>
+      page.evaluate(() => window.localStorage.getItem('better-auth:token')),
+    ).toBe('test-session-token');
+
+    expect(mocks.signUpCalls).toHaveLength(1);
+    expect(mocks.signUpCalls[0]).toMatchObject({
+      email: 'new.owner@example.com',
+      name: 'New Owner',
+      companyName: 'HavenHost',
+      password: 'Sup3rSecret!',
+    });
+
+    expect(mocks.signInCalls).toHaveLength(1);
+    expect(mocks.signInCalls[0]).toMatchObject({
+      email: 'new.owner@example.com',
+      password: 'Sup3rSecret!',
+    });
+
+    expect(mocks.validateSessionCalls.length).toBeGreaterThan(0);
+  });
+
+  test('allows an existing user to sign in', async ({ page }) => {
+    const mocks = await setupConvexMocks(page, {
+      user: { id: 'user_existing', name: 'Existing Owner' },
+    });
+
+    await page.goto('/login');
+
+    await page.getByLabel('Email').fill('OWNER@example.com  ');
+    await page.getByLabel('Password').fill('owner-password!');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(
+      page.getByRole('heading', { level: 2, name: /companies/i }),
+    ).toBeVisible();
+
+    await expect.poll(() =>
+      page.evaluate(() => window.localStorage.getItem('better-auth:token')),
+    ).toBe('test-session-token');
+
+    expect(mocks.signUpCalls).toHaveLength(0);
+    expect(mocks.signInCalls).toHaveLength(1);
+    expect(mocks.signInCalls[0]).toMatchObject({
+      email: 'owner@example.com',
+      password: 'owner-password!',
+    });
+
+    expect(mocks.validateSessionCalls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- navigate to the login route in the Playwright signup flow before switching into the create-account mode
- wait for the create-account heading and target the name field by placeholder to make the test resilient

## Testing
- npm run test:e2e -- --reporter=line

------
https://chatgpt.com/codex/tasks/task_e_68d999de4f10832cad191a844b0eed36