### PR TITLE
Fix npm build by tightening types across admin UI

### DIFF
--- a/convex/company.ts
+++ b/convex/company.ts
@@ -21,14 +21,14 @@ const getAppBaseUrl = () => process.env.APP_BASE_URL ?? "http://localhost:5173";
 async function getSessionForToken(ctx: ActionCtx, token: string) {
   const sessions = (await ctx.runQuery(internal.authStore.getAll, {
     table: "authSessions",
-  })) as Array<Record<string, unknown>>;
+  })) as Array<Doc<"authSessions">>;
   return sessions.find((session) => session.token === token) ?? null;
 }
 
 async function getUserDocByAuthId(ctx: ActionCtx, authUserId: string) {
   const users = (await ctx.runQuery(internal.authStore.getAll, {
     table: "users",
-  })) as Array<Record<string, unknown>>;
+  })) as Array<Doc<"users">>;
   return users.find((user) => user.id === authUserId) ?? null;
 }
 
@@ -135,7 +135,7 @@ export const inviteUser = action({
 
     const users = (await ctx.runQuery(internal.authStore.getAll, {
       table: "users",
-    })) as Array<Record<string, unknown>>;
+    })) as Array<Doc<"users">>;
     const existingUser = users.find(
       (user) =>
         user.email?.toLowerCase() === emailLower &&
@@ -187,7 +187,7 @@ export const inviteUser = action({
         companyId: inviter.companyId,
         email: emailLower,
       }
-    )) as Record<string, unknown> | null;
+    )) as Doc<"companyInvitations"> | null;
 
     if (existingInvitation) {
       await ctx.runMutation(internal.companyStore.updateInvitation, {

--- a/src/components/admin/boolean-input.tsx
+++ b/src/components/admin/boolean-input.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import { Switch } from "@/components/ui/switch";
 import { FormError, FormField, FormLabel } from "@/components/admin/form";
 import { useInput, FieldTitle } from "ra-core";
+import type { Validator } from "ra-core";
 import { InputHelperText } from "./input-helper-text";
 
 export const BooleanInput = (props: BooleanInputProps) => {
@@ -84,5 +85,5 @@ export interface BooleanInputProps {
   parse?: (value: unknown) => unknown;
   resource?: string;
   source: string;
-  validate?: unknown;
+  validate?: Validator | Validator[];
 }

--- a/src/components/admin/data-table.tsx
+++ b/src/components/admin/data-table.tsx
@@ -258,7 +258,10 @@ const DataTableRow = ({
 };
 
 const isPromise = (value: unknown): value is Promise<unknown> =>
-  value && typeof value.then === "function";
+  typeof value === "object" &&
+  value !== null &&
+  "then" in value &&
+  typeof (value as { then?: unknown }).then === "function";
 
 const DataTableEmpty = () => {
   return (

--- a/src/components/admin/edit-guesser.tsx
+++ b/src/components/admin/edit-guesser.tsx
@@ -24,6 +24,11 @@ export const EditGuesser = (props: { enableLog?: boolean }) => {
   );
 };
 
+const getStringProp = (props: Record<string, unknown>, key: string) => {
+  const value = props[key];
+  return typeof value === "string" ? value : undefined;
+};
+
 const EditViewGuesser = (props: { enableLog?: boolean }) => {
   const resource = useResourceContext();
 
@@ -91,7 +96,9 @@ ${representation}
 
 const editFieldTypes: InferredTypeMap = {
   form: {
-    component: (props: Record<string, unknown>) => <SimpleForm {...props} />,
+    component: (props: Record<string, unknown>) => (
+      <SimpleForm {...(props as { children: ReactNode })} />
+    ),
     representation: (
       _props: Record<string, unknown>,
       children: { getRepresentation: () => string }[]
@@ -102,32 +109,72 @@ ${children
         </SimpleForm>`,
   },
   reference: {
-    component: (props: Record<string, unknown>) => (
-      <ReferenceInput source={props.source} reference={props.reference}>
-        <AutocompleteInput />
-      </ReferenceInput>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<ReferenceInput source="${props.source}" reference="${props.reference}">
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      return (
+        <ReferenceInput source={source} reference={reference}>
+          <AutocompleteInput />
+        </ReferenceInput>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<ReferenceInput source="${source}" reference="${reference}">
                   <AutocompleteInput />
-              </ReferenceInput>`,
+              </ReferenceInput>`;
+    },
   },
   referenceArray: {
-    component: (props: Record<string, unknown>) => (
-      <ReferenceArrayInput {...props} />
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<ReferenceArrayInput source="${props.source}" reference="${props.reference}" />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      return (
+        <ReferenceArrayInput
+          {...(props as Record<string, unknown>)}
+          source={source}
+          reference={reference}
+        />
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<ReferenceArrayInput source="${source}" reference="${reference}" />`;
+    },
   },
   boolean: {
-    component: (props: Record<string, unknown>) => <BooleanInput {...props} />,
-    representation: (props: Record<string, unknown>) =>
-      `<BooleanInput source="${props.source}" />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return <BooleanInput {...(props as Record<string, unknown>)} source={source} />;
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<BooleanInput source="${source}" />`;
+    },
   },
   string: {
-    component: (props: Record<string, unknown>) => <TextInput {...props} />,
-    representation: (props: Record<string, unknown>) =>
-      `<TextInput source="${props.source}" />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return <TextInput {...(props as Record<string, unknown>)} source={source} />;
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<TextInput source="${source}" />`;
+    },
   },
 };
 

--- a/src/components/admin/file-input.tsx
+++ b/src/components/admin/file-input.tsx
@@ -139,7 +139,7 @@ export const FileInput = (props: FileInputProps) => {
     }
   };
 
-  const onRemove = (file: File) => async () => {
+  const onRemove = (file: File | TransformedFile) => async () => {
     if (validateFileRemoval) {
       try {
         await validateFileRemoval(file);
@@ -231,7 +231,7 @@ export const FileInput = (props: FileInputProps) => {
 
       {children && (
         <div className="previews flex flex-col gap-1">
-          {files.map((file: File, index: number) => (
+          {files.map((file: File | TransformedFile, index: number) => (
             <FileInputPreview
               key={index}
               file={file}
@@ -259,11 +259,11 @@ export type FileInputProps = Omit<InputProps, "type"> & {
   minSize?: DropzoneOptions["minSize"];
   multiple?: DropzoneOptions["multiple"];
   options?: DropzoneOptions;
-  onRemove?: (file: File) => void;
+  onRemove?: (file: File | TransformedFile) => void;
   placeholder?: ReactNode;
   removeIcon?: ComponentType<{ className?: string }>;
   inputProps?: DropzoneInputProps & React.ComponentProps<"input">;
-  validateFileRemoval?(file: File): boolean | Promise<boolean>;
+  validateFileRemoval?(file: File | TransformedFile): boolean | Promise<boolean>;
 };
 
 export interface TransformedFile {
@@ -271,6 +271,29 @@ export interface TransformedFile {
   src: string;
   title: string;
 }
+
+const isTransformedFile = (file: unknown): file is TransformedFile =>
+  typeof file === "object" &&
+  file !== null &&
+  "rawFile" in file &&
+  (file as { rawFile?: unknown }).rawFile instanceof File &&
+  "src" in file &&
+  typeof (file as { src?: unknown }).src === "string";
+
+const getPreviewUrl = (file: File | TransformedFile) => {
+  if (isTransformedFile(file)) {
+    const rawPreview =
+      "preview" in file.rawFile &&
+      typeof (file.rawFile as { preview?: unknown }).preview === "string"
+        ? ((file.rawFile as { preview?: unknown }).preview as string)
+        : undefined;
+    return rawPreview ?? file.src;
+  }
+  if ("preview" in file && typeof file.preview === "string") {
+    return file.preview;
+  }
+  return undefined;
+};
 
 export const FileInputPreview = (props: FileInputPreviewProps) => {
   const {
@@ -288,8 +311,7 @@ export const FileInputPreview = (props: FileInputPreviewProps) => {
 
   useEffect(() => {
     return () => {
-      const preview = file.rawFile ? file.rawFile.preview : file.preview;
-
+      const preview = getPreviewUrl(file);
       if (preview) {
         window.URL.revokeObjectURL(preview);
       }
@@ -314,7 +336,7 @@ export const FileInputPreview = (props: FileInputPreviewProps) => {
 };
 
 export interface FileInputPreviewProps extends HTMLAttributes<HTMLDivElement> {
-  file: File;
+  file: File | TransformedFile;
   onRemove: () => void;
   removeIcon?: React.ComponentType<{ className?: string }>;
 }

--- a/src/components/admin/filter-form.tsx
+++ b/src/components/admin/filter-form.tsx
@@ -143,9 +143,9 @@ const isEmptyValue = (filterValue: unknown): boolean => {
 
   // If one of the value leaf is not empty
   // the value is considered not empty
-  if (typeof filterValue === "object") {
-    return Object.keys(filterValue).every((key) =>
-      isEmptyValue(filterValue[key])
+  if (filterValue && typeof filterValue === "object") {
+    return Object.values(filterValue as Record<string, unknown>).every(
+      (value) => isEmptyValue(value)
     );
   }
 
@@ -440,25 +440,34 @@ export const FilterButtonMenuItem = React.forwardRef<
 >((props, ref) => {
   const { filter, onShow, onHide, displayed } = props;
   const resource = useResourceContext(props);
+  const source =
+    typeof filter.props.source === "string" ? filter.props.source : "";
+  const defaultValue = filter.props.defaultValue;
   const handleShow = useCallback(() => {
+    if (!source) {
+      return;
+    }
     onShow({
-      source: filter.props.source,
-      defaultValue: filter.props.defaultValue,
+      source,
+      defaultValue,
     });
-  }, [filter.props.defaultValue, filter.props.source, onShow]);
+  }, [defaultValue, onShow, source]);
   const handleHide = useCallback(() => {
+    if (!source) {
+      return;
+    }
     onHide({
-      source: filter.props.source,
+      source,
     });
-  }, [filter.props.source, onHide]);
+  }, [onHide, source]);
 
   return (
     <div
       className={cn(
         "new-filter-item flex items-center px-2 py-1.5 text-sm cursor-pointer hover:bg-accent rounded-sm",
-        filter.props.disabled && "opacity-50 cursor-not-allowed"
+        filter.props.disabled ? "opacity-50 cursor-not-allowed" : undefined
       )}
-      data-key={filter.props.source}
+      data-key={source}
       data-default-value={filter.props.defaultValue}
       onClick={
         filter.props.disabled ? undefined : displayed ? handleHide : handleShow
@@ -472,8 +481,8 @@ export const FilterButtonMenuItem = React.forwardRef<
       </div>
       <div>
         <FieldTitle
-          label={filter.props.label}
-          source={filter.props.source}
+          label={filter.props.label as React.ReactNode}
+          source={source}
           resource={resource}
         />
       </div>

--- a/src/components/admin/form.tsx
+++ b/src/components/admin/form.tsx
@@ -265,7 +265,7 @@ export type SaveButtonProps = SaveButtonBaseProps &
     alwaysEnable?: boolean;
   };
 
-const valueOrDefault = (value: unknown, defaultValue: unknown) =>
+const valueOrDefault = <T,>(value: T | undefined, defaultValue: T): T =>
   typeof value === "undefined" ? defaultValue : value;
 
 export {

--- a/src/components/admin/list-guesser.tsx
+++ b/src/components/admin/list-guesser.tsx
@@ -134,10 +134,29 @@ ${inferredChild.getRepresentation()}
   return <ListView {...rest}>{child}</ListView>;
 };
 
+const getStringProp = (props: Record<string, unknown>, key: string) => {
+  const value = props[key];
+  return typeof value === "string" ? value : undefined;
+};
+
 const listFieldTypes = {
   table: {
     component: (props: Record<string, unknown>) => {
-      return <DataTable {...props} />;
+      const {
+        children,
+        source: _unusedSource,
+        reference: _unusedReference,
+        ...rest
+      } = props as {
+        children?: React.ReactNode;
+        source?: unknown;
+        reference?: unknown;
+      };
+      return (
+        <DataTable {...(rest as Record<string, unknown>)}>
+          {children as React.ReactNode}
+        </DataTable>
+      );
     },
     representation: (
       _props: Record<string, unknown>,
@@ -151,64 +170,121 @@ ${children
   },
 
   reference: {
-    component: (props: Record<string, unknown>) => (
-      <DataTable.Col source={props.source}>
-        <ReferenceField source={props.source} reference={props.reference} />
-      </DataTable.Col>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<DataTable.Col source="${props.source}">
-                <ReferenceField source="${props.source}" reference="${props.reference}" />
-            </DataTable.Col>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      return (
+        <DataTable.Col source={source}>
+          <ReferenceField source={source} reference={reference} />
+        </DataTable.Col>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<DataTable.Col source="${source}">
+                <ReferenceField source="${source}" reference="${reference}" />
+            </DataTable.Col>`;
+    },
   },
   array: {
-    component: ({
-      children,
-      ...props
-    }: Record<string, unknown> & { children: React.ReactNode }) => {
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      const children = props.children as React.ReactNode;
       const childrenArray = React.Children.toArray(children);
+      const badgeSource =
+        childrenArray.length > 0 &&
+        React.isValidElement(childrenArray[0]) &&
+        typeof (childrenArray[0].props as Record<string, unknown>).source ===
+          "string"
+          ? ((childrenArray[0].props as Record<string, unknown>).source as string)
+          : undefined;
       return (
-        <DataTable.Col source={props.source}>
-          <ArrayField source={props.source}>
+        <DataTable.Col source={source}>
+          <ArrayField source={source}>
             <SingleFieldList>
-              <BadgeField
-                source={
-                  childrenArray.length > 0 &&
-                  React.isValidElement(childrenArray[0]) &&
-                  (childrenArray[0].props as Record<string, unknown>).source
-                }
-              />
+              {badgeSource ? <BadgeField source={badgeSource} /> : null}
             </SingleFieldList>
           </ArrayField>
         </DataTable.Col>
       );
     },
-    representation: (props: Record<string, unknown>, children: unknown[]) =>
-      `<DataTable.Col source="${props.source}">
-               <ArrayField source="${props.source}">
+    representation: (props: Record<string, unknown>, children: unknown[]) => {
+      const source = getStringProp(props, "source") ?? "";
+      const badgeSource = (() => {
+        if (children.length === 0) {
+          return "";
+        }
+        const firstChild = children[0];
+        if (
+          firstChild &&
+          typeof firstChild === "object" &&
+          firstChild !== null &&
+          "getProps" in firstChild &&
+          typeof (firstChild as { getProps?: unknown }).getProps === "function"
+        ) {
+          const childProps = (firstChild as {
+            getProps: () => Record<string, unknown>;
+          }).getProps();
+          return getStringProp(childProps, "source") ?? "";
+        }
+        return "";
+      })();
+      return `<DataTable.Col source="${source}">
+               <ArrayField source="${source}">
                     <SingleFieldList>
-                        <BadgeField source="${
-                          children.length > 0 && children[0].getProps().source
-                        }" />
+                        <BadgeField source="${badgeSource}" />
                    </SingleFieldList>
                 </ArrayField>
-            </DataTable.Col>`,
+            </DataTable.Col>`;
+    },
   },
   referenceArray: {
-    component: (props: Record<string, unknown>) => (
-      <DataTable.Col {...props}>
-        <ReferenceArrayField {...props} />
-      </DataTable.Col>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<DataTable.Col source="${props.source}">
-                <ReferenceArrayField source="${props.source}" reference="${props.reference}" />
-            </DataTable.Col>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      const { children, ...rest } = props as { children?: React.ReactNode };
+      return (
+        <DataTable.Col {...(rest as Record<string, unknown>)} source={source}>
+          <ReferenceArrayField
+            {...(rest as Record<string, unknown>)}
+            source={source}
+            reference={reference}
+          >
+            {children as React.ReactNode}
+          </ReferenceArrayField>
+        </DataTable.Col>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<DataTable.Col source="${source}">
+                <ReferenceArrayField source="${source}" reference="${reference}" />
+            </DataTable.Col>`;
+    },
   },
   string: {
-    component: DataTable.Col,
-    representation: (props: Record<string, unknown>) =>
-      `<DataTable.Col source="${props.source}" />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return <DataTable.Col source={source} />;
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<DataTable.Col source="${source}" />`;
+    },
   },
 };
 

--- a/src/components/admin/number-field.tsx
+++ b/src/components/admin/number-field.tsx
@@ -48,7 +48,7 @@ export interface NumberFieldProps<
     HTMLAttributes<HTMLSpanElement> {
   locales?: string | string[];
   options?: object;
-  transform?: (value: unknown) => number;
+  transform?: (value: unknown) => unknown;
 }
 
 const defaultTransform = (value: unknown) =>

--- a/src/components/admin/select-input.tsx
+++ b/src/components/admin/select-input.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
   type ReactElement,
+  type ChangeEvent,
 } from "react";
 
 import { FormError, FormField, FormLabel } from "@/components/admin/form";
@@ -150,7 +151,7 @@ export const SelectInput = (props: SelectInputProps) => {
   );
 
   const handleChange = useCallback(
-    async (value: string) => {
+    (value: string) => {
       if (value === emptyValue) {
         field.onChange(emptyValue);
       } else {
@@ -164,17 +165,43 @@ export const SelectInput = (props: SelectInputProps) => {
     [field, getChoiceValue, emptyValue, allChoices]
   );
 
+  const handleCreateSuggestionChange = useCallback(
+    (input: string | ChangeEvent<unknown> | unknown) => {
+      if (typeof input === "string") {
+        handleChange(input);
+        return;
+      }
+      if (
+        input &&
+        typeof input === "object" &&
+        "target" in input &&
+        (input as { target?: unknown }).target &&
+        typeof (input as { target?: unknown }).target === "object" &&
+        (input as { target: unknown }).target !== null &&
+        "value" in (input as { target: Record<string, unknown> }).target
+      ) {
+        const eventValue = (input as {
+          target: { value?: unknown };
+        }).target.value;
+        if (typeof eventValue === "string") {
+          handleChange(eventValue);
+        }
+      }
+    },
+    [handleChange]
+  );
+
   const {
     getCreateItem,
     handleChange: handleChangeWithCreateSupport,
     createElement,
-  } = useSupportCreateSuggestion({
+  } = useSupportCreateSuggestion<string>({
     create,
     createLabel,
     createValue,
     createHintValue,
     onCreate,
-    handleChange,
+    handleChange: handleCreateSuggestionChange,
     optionText,
   });
 
@@ -293,7 +320,7 @@ export const SelectInput = (props: SelectInputProps) => {
 export type SelectInputProps = ChoicesProps &
   // Source is optional as SelectInput can be used inside a ReferenceInput that already defines the source
   Partial<InputProps> &
-  Omit<SupportCreateSuggestionOptions, "handleChange"> & {
+  Omit<SupportCreateSuggestionOptions<string>, "handleChange"> & {
     emptyText?: string | ReactElement;
     emptyValue?: unknown;
     onChange?: (value: string) => void;

--- a/src/components/admin/show-guesser.tsx
+++ b/src/components/admin/show-guesser.tsx
@@ -30,6 +30,11 @@ export const ShowGuesser = (props: { enableLog?: boolean }) => (
   </ShowBase>
 );
 
+const getStringProp = (props: Record<string, unknown>, key: string) => {
+  const value = props[key];
+  return typeof value === "string" ? value : undefined;
+};
+
 const ShowViewGuesser = (props: { enableLog?: boolean }) => {
   const resource = useResourceContext();
 
@@ -98,9 +103,10 @@ ${inferredChild.getRepresentation()}
 
 const showFieldTypes: InferredTypeMap = {
   show: {
-    component: (props: Record<string, unknown>) => (
-      <div className="flex flex-col gap-4">{props.children}</div>
-    ),
+    component: (props: Record<string, unknown>) => {
+      const children = props.children as ReactNode;
+      return <div className="flex flex-col gap-4">{children}</div>;
+    },
     representation: (
       _props: Record<string, unknown>,
       children: { getRepresentation: () => string }[]
@@ -111,98 +117,192 @@ ${children
         </div>`,
   },
   reference: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField source={props.source}>
-        <ReferenceField source={props.source} reference={props.reference} />
-      </RecordField>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}">
-                <ReferenceField source="${props.source}" reference="${props.reference}" />
-            </RecordField>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      return (
+        <RecordField source={source}>
+          <ReferenceField source={source} reference={reference} />
+        </RecordField>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<RecordField source="${source}">
+                <ReferenceField source="${source}" reference="${reference}" />
+            </RecordField>`;
+    },
   },
   array: {
-    component: ({
-      children,
-      ...props
-    }: Record<string, unknown> & { children: React.ReactNode }) => {
-      const childrenArray = Children.toArray(children);
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      const childrenNodes = props.children as ReactNode;
+      const childrenArray = Children.toArray(childrenNodes);
       return (
-        <RecordField source={props.source}>
-          <ArrayField source={props.source}>
+        <RecordField source={source}>
+          <ArrayField source={source}>
             <SingleFieldList>
-              <BadgeField
-                source={
-                  childrenArray.length > 0 &&
-                  isValidElement(childrenArray[0]) &&
-                  (childrenArray[0].props as Record<string, unknown>).source
-                }
-              />
+              {childrenArray.length > 0 &&
+              isValidElement(childrenArray[0]) &&
+              typeof (childrenArray[0].props as Record<string, unknown>).source ===
+                "string" ? (
+                <BadgeField
+                  source={
+                    (childrenArray[0].props as Record<string, unknown>)
+                      .source as string
+                  }
+                />
+              ) : null}
             </SingleFieldList>
           </ArrayField>
         </RecordField>
       );
     },
-    representation: (props: Record<string, unknown>, children: unknown[]) =>
-      `<RecordField source="${props.source}">
-                <ArrayField source="${props.source}">
+    representation: (props: Record<string, unknown>, children: unknown[]) => {
+      const source = getStringProp(props, "source") ?? "";
+      const badgeSource = (() => {
+        if (children.length === 0) {
+          return "";
+        }
+        const firstChild = children[0];
+        if (
+          firstChild &&
+          typeof firstChild === "object" &&
+          firstChild !== null &&
+          "getProps" in firstChild &&
+          typeof (firstChild as { getProps?: unknown }).getProps === "function"
+        ) {
+          const childProps = (firstChild as {
+            getProps: () => Record<string, unknown>;
+          }).getProps();
+          return getStringProp(childProps, "source") ?? "";
+        }
+        return "";
+      })();
+      return `<RecordField source="${source}">
+                <ArrayField source="${source}">
                     <SingleFieldList>
-                        <BadgeField source="${
-                          children.length > 0 && children[0].getProps().source
-                        }" />
+                        <BadgeField source="${badgeSource}" />
                     </SingleFieldList>
                 </ArrayField>
-            </RecordField>`,
+            </RecordField>`;
+    },
   },
   referenceArray: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField source={props.source}>
-        <ReferenceArrayField {...props} />
-      </RecordField>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}">
-                <ReferenceArrayField source="${props.source}" reference="${props.reference}" />
-            </RecordField>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      const reference = getStringProp(props, "reference");
+      if (!source || !reference) {
+        return null;
+      }
+      const {
+        children,
+        source: _unusedSource,
+        reference: _unusedReference,
+        ...rest
+      } = props as {
+        children?: ReactNode;
+        source?: unknown;
+        reference?: unknown;
+      };
+      return (
+        <RecordField source={source}>
+          <ReferenceArrayField
+            {...(rest as Record<string, unknown>)}
+            source={source}
+            reference={reference}
+          >
+            {children as ReactNode}
+          </ReferenceArrayField>
+        </RecordField>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      const reference = getStringProp(props, "reference") ?? "";
+      return `<RecordField source="${source}">
+                <ReferenceArrayField source="${source}" reference="${reference}" />
+            </RecordField>`;
+    },
   },
   boolean: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField
-        source={props.source}
-        render={(record) => (record[props.source] ? "Yes" : "No")}
-      />
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}" render={record => record[${props.source}] ? 'Yes' : 'No'} />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return (
+        <RecordField
+          source={source}
+          render={(record: Record<string, unknown>) => {
+            const key = source as keyof typeof record;
+            return Boolean(record[key]) ? "Yes" : "No";
+          }}
+        />
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<RecordField source="${source}" render={record => record[${source}] ? 'Yes' : 'No'} />`;
+    },
   },
   date: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField source={props.source}>
-        <DateField source={props.source} />
-      </RecordField>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}">
-                <DateField source="${props.source}" />
-            </RecordField>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return (
+        <RecordField source={source}>
+          <DateField source={source} />
+        </RecordField>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<RecordField source="${source}">
+                <DateField source="${source}" />
+            </RecordField>`;
+    },
   },
   number: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField source={props.source}>
-        <NumberField source={props.source} />
-      </RecordField>
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}">
-                <NumberField source="${props.source}" />
-            </RecordField>`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return (
+        <RecordField source={source}>
+          <NumberField source={source} />
+        </RecordField>
+      );
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<RecordField source="${source}">
+                <NumberField source="${source}" />
+            </RecordField>`;
+    },
   },
   string: {
-    component: (props: Record<string, unknown>) => (
-      <RecordField source={props.source} />
-    ),
-    representation: (props: Record<string, unknown>) =>
-      `<RecordField source="${props.source}" />`,
+    component: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source");
+      if (!source) {
+        return null;
+      }
+      return <RecordField source={source} />;
+    },
+    representation: (props: Record<string, unknown>) => {
+      const source = getStringProp(props, "source") ?? "";
+      return `<RecordField source="${source}" />`;
+    },
   },
 };
 

--- a/src/components/admin/toggle-filter-button.tsx
+++ b/src/components/admin/toggle-filter-button.tsx
@@ -13,7 +13,7 @@ export const ToggleFilterButton = ({
   className,
 }: {
   label: React.ReactElement | string;
-  value: unknown;
+  value: Record<string, unknown>;
   className?: string;
   size?: "default" | "sm" | "lg" | "icon" | null | undefined;
 }) => {

--- a/src/lib/__tests__/authProvider.test.ts
+++ b/src/lib/__tests__/authProvider.test.ts
@@ -42,7 +42,9 @@ describe("authProvider", () => {
       ),
     );
 
-    await expect(authProvider.checkAuth()).rejects.toThrowError("Session expired");
+    await expect(authProvider.checkAuth({})).rejects.toThrowError(
+      "Session expired"
+    );
 
     expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
     expect(localStorage.getItem(USER_KEY)).toBeNull();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -32,7 +32,11 @@ const buildPath = (reference: unknown) => {
 };
 
 class MockConvexHttpClient {
-  constructor(private readonly baseUrl: string) {}
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
 
   private async request(
     type: "queries" | "mutations" | "actions",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 const configuredBase = process.env.BASE_PATH;


### PR DESCRIPTION
## Summary
- replace loose Convex query typings with generated Doc types in company invitation action
- harden admin inference components and filters to handle optional props without raising TypeScript errors
- update shared hooks and inputs to accept event-like values, clean up file previews, and configure Vitest correctly

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf8c2fb8c832c9e7229113ca21986