### PR TITLE
chore: add Husky pre-commit completion rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,19 @@ description: Always follow test-driven development practices
 - Only then proceed to refactor or extend the code, keeping the test suite green at each step.
 - Prefer unit or integration tests that align with the project's existing testing stack (Vitest for unit, Playwright for e2e) unless the user specifies otherwise.
 
+## husky-precommit.mdc
+
+---
+
+alwaysApply: true
+description: Ensure Husky pre-commit checks pass before completing tasks
+
+---
+
+# Husky Pre-commit Checks
+
+- All Husky pre-commit checks must pass before a task can be deemed complete.
+
 ## context7.mdc
 
 ---


### PR DESCRIPTION
## Summary
- add an alwaysApply rule documenting that Husky pre-commit checks must pass before completing a task

## Testing
- pnpm lint
- pnpm typecheck
- pnpm format:check
- pnpm openapi:validate
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68dc46f4efa8832c82ad297945d6be41