### PR TITLE
refactor: simplify admin dashboard pagination

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -252,6 +252,7 @@ export default defineSchema({
     transcriptRef: v.optional(v.string()),
   })
     .index("by_company", ["companyId"])
+    .index("by_company_createdAt", ["companyId", "createdAt"])
     .index("by_property", ["propertyId"])
     .index("by_intent", ["intent"]),
 
@@ -267,6 +268,8 @@ export default defineSchema({
     summary: v.optional(v.string()),
     transcriptRef: v.optional(v.string()),
   })
+    .index("by_company", ["companyId"])
+    .index("by_company_createdAt", ["companyId", "createdAt"])
     .index("by_property_status", ["propertyId", "status"])
     .index("by_priority", ["propertyId", "priority"]),
 


### PR DESCRIPTION
## Summary
- drop the bespoke pagination helper in the admin dashboard query and rely on Convex's `collect` helper
- keep explicit companyId filtering on escalations to mirror the previous behaviour and satisfy review feedback

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc461f4310832c8f7e5f3cca897f8a