### PR TITLE
Create phone numbers management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,12 +17,7 @@ import {
   PropertyShow,
 } from "@/resources/properties";
 import { UserCreate, UserEdit, UserList, UserShow } from "@/resources/users";
-import {
-  NumberCreate,
-  NumberEdit,
-  NumberList,
-  NumberShow,
-} from "@/resources/numbers";
+import { PhoneNumberList } from "@/resources/numbers";
 import { SignupPage } from "@/components/admin/login-page";
 import KnowledgeBasePage from "@/pages/knowledge-base";
 
@@ -59,11 +54,9 @@ function App() {
       />
       <Resource
         name="numbers"
-        list={NumberList}
-        create={NumberCreate}
-        edit={NumberEdit}
-        show={NumberShow}
+        list={PhoneNumberList}
         recordRepresentation="e164"
+        options={{ label: "Phone Numbers" }}
       />
       <CustomRoutes>
         <Route path="/knowledge-base" element={<KnowledgeBasePage />} />

--- a/src/resources/numbers.tsx
+++ b/src/resources/numbers.tsx
@@ -1,127 +1,304 @@
-import { required } from "ra-core";
-import { Create } from "@/components/admin/create";
-import { DataTable } from "@/components/admin/data-table";
-import { DateField } from "@/components/admin/date-field";
-import { Edit } from "@/components/admin/edit";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  Identifier,
+  RaRecord,
+  useGetList,
+  useNotify,
+  useRecordContext,
+  useRefresh,
+  useUpdate,
+} from "ra-core";
 import { List } from "@/components/admin/list";
-import { RecordField } from "@/components/admin/record-field";
+import { DataTable } from "@/components/admin/data-table";
 import { ReferenceField } from "@/components/admin/reference-field";
-import { ReferenceInput } from "@/components/admin/reference-input";
-import { Show } from "@/components/admin/show";
-import { SimpleForm } from "@/components/admin/simple-form";
-import { AutocompleteInput } from "@/components/admin/autocomplete-input";
 import { TextField } from "@/components/admin/text-field";
-import { TextInput } from "@/components/admin/text-input";
-import { NumberInput } from "@/components/admin/number-input";
-import { ArrayInput } from "@/components/admin/array-input";
-import { SimpleFormIterator } from "@/components/admin/simple-form-iterator";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Loader2 } from "lucide-react";
 
-export const NumberList = () => (
-  <List>
-    <DataTable>
-      <DataTable.Col source="e164" label="Phone Number">
-        <TextField source="e164" />
-      </DataTable.Col>
-      <DataTable.Col source="companyId" label="Company">
-        <ReferenceField reference="companies" source="companyId">
-          <TextField source="name" />
-        </ReferenceField>
-      </DataTable.Col>
-      <DataTable.Col source="assignedPropertyId" label="Property">
-        <ReferenceField reference="properties" source="assignedPropertyId">
-          <TextField source="name" />
-        </ReferenceField>
-      </DataTable.Col>
-      <DataTable.Col source="createdAt" label="Created">
-        <DateField source="createdAt" showTime />
-      </DataTable.Col>
-    </DataTable>
-  </List>
-);
+const placeholderTextClassName = "text-muted-foreground";
 
-export const NumberCreate = () => (
-  <Create>
-    <SimpleForm defaultValues={{ createdAt: Date.now() }}>
-      <ReferenceInput source="companyId" reference="companies">
-        <AutocompleteInput
-          label="Company"
-          optionText="name"
-          validate={[required()]}
-        />
-      </ReferenceInput>
-      <TextInput source="e164" label="Phone Number" validate={[required()]} />
-      <ReferenceInput source="assignedPropertyId" reference="properties">
-        <AutocompleteInput label="Assigned Property" optionText="name" />
-      </ReferenceInput>
-      <TextInput source="assignedQueue" label="Assigned Queue" />
-      <TextInput
-        source="hours.fallbackNumber"
-        label="Fallback Number"
-        placeholder="+1..."
+type PhoneNumberRecord = RaRecord<Identifier> & {
+  e164: string;
+  assignedPropertyId?: Identifier | null;
+  assignedQueue?: string | null;
+};
+
+type PropertySummary = {
+  id: Identifier;
+  name: string;
+};
+
+type PropertyOption = {
+  value: string;
+  label: string;
+};
+
+type AssignPropertyDialogProps = {
+  record: PhoneNumberRecord | null;
+  onClose: () => void;
+  options: PropertyOption[];
+  valueToId: Map<string, Identifier>;
+  isLoading: boolean;
+  error?: unknown;
+};
+
+const AssignedQueueCell = () => {
+  const record = useRecordContext<PhoneNumberRecord>();
+  if (!record) {
+    return null;
+  }
+
+  return record.assignedQueue ? (
+    <span>{record.assignedQueue}</span>
+  ) : (
+    <span className={placeholderTextClassName}>Unassigned</span>
+  );
+};
+
+const AssignPropertyButton = ({
+  onAssign,
+}: {
+  onAssign: (record: PhoneNumberRecord) => void;
+}) => {
+  const record = useRecordContext<PhoneNumberRecord>();
+  if (!record) {
+    return null;
+  }
+
+  const label = record.assignedPropertyId ? "Change assignment" : "Assign property";
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => onAssign(record)}
+    >
+      {label}
+    </Button>
+  );
+};
+
+const AssignPropertyDialog = ({
+  record,
+  onClose,
+  options,
+  valueToId,
+  isLoading,
+  error,
+}: AssignPropertyDialogProps) => {
+  const [selectedValue, setSelectedValue] = useState<string>("");
+  const [update, { isPending }] = useUpdate<PhoneNumberRecord>();
+  const notify = useNotify();
+  const refresh = useRefresh();
+
+  useEffect(() => {
+    if (record) {
+      setSelectedValue(
+        record.assignedPropertyId != null ? String(record.assignedPropertyId) : "",
+      );
+    } else {
+      setSelectedValue("");
+    }
+  }, [record]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!record) return;
+
+    const nextValue =
+      selectedValue === ""
+        ? null
+        : valueToId.get(selectedValue) ?? selectedValue;
+
+    try {
+      await update(
+        "numbers",
+        {
+          id: record.id,
+          data: {
+            assignedPropertyId: nextValue,
+          },
+          previousData: record,
+        },
+        { mutationMode: "pessimistic", returnPromise: true },
+      );
+      notify("Phone number assignment updated.", { type: "info" });
+      refresh();
+      onClose();
+    } catch (_error) {
+      notify("Failed to update the phone number assignment.", {
+        type: "warning",
+      });
+    }
+  }, [record, selectedValue, valueToId, update, notify, refresh, onClose]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const disableSubmit = isPending || isLoading || !!error;
+
+  return (
+    <Dialog open={record != null} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Assign property</DialogTitle>
+          <DialogDescription>
+            {record
+              ? `Select which property should receive calls from ${record.e164}.`
+              : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              We were unable to load the list of properties. Please try again later.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <Select
+              value={selectedValue}
+              onValueChange={setSelectedValue}
+              disabled={isLoading || isPending}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a property" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Unassigned</SelectItem>
+                {options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {!isLoading && options.length === 0 ? (
+              <p className={placeholderTextClassName}>
+                No properties are available yet. Add a property to assign this number.
+              </p>
+            ) : null}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={disableSubmit}>
+            {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export const PhoneNumberList = () => {
+  const [selectedRecord, setSelectedRecord] = useState<PhoneNumberRecord | null>(
+    null,
+  );
+
+  const handleOpenDialog = useCallback((record: PhoneNumberRecord) => {
+    setSelectedRecord(record);
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    setSelectedRecord(null);
+  }, []);
+
+  const {
+    data: properties = [],
+    isPending: isLoadingProperties,
+    error: propertiesError,
+  } = useGetList<PropertySummary>("properties", {
+    pagination: { page: 1, perPage: 100 },
+    sort: { field: "name", order: "ASC" },
+  });
+
+  const options = useMemo<PropertyOption[]>(() => {
+    return properties.map((property) => ({
+      value: String(property.id),
+      label: property.name,
+    }));
+  }, [properties]);
+
+  const valueToId = useMemo(() => {
+    const entries = new Map<string, Identifier>();
+    for (const property of properties) {
+      entries.set(String(property.id), property.id);
+    }
+    return entries;
+  }, [properties]);
+
+  return (
+    <>
+      <List title="Phone Numbers">
+        <DataTable>
+          <DataTable.Col source="e164" label="Phone Number">
+            <TextField source="e164" />
+          </DataTable.Col>
+          <DataTable.Col
+            source="assignedPropertyId"
+            label="Assigned Property"
+            disableSort
+          >
+            <ReferenceField
+              reference="properties"
+              source="assignedPropertyId"
+              empty={<span className={placeholderTextClassName}>Unassigned</span>}
+              link={false}
+            >
+              <TextField source="name" />
+            </ReferenceField>
+          </DataTable.Col>
+          <DataTable.Col source="assignedQueue" label="Assigned Queue" disableSort>
+            <AssignedQueueCell />
+          </DataTable.Col>
+          <DataTable.Col label="Actions" disableSort>
+            <AssignPropertyButton onAssign={handleOpenDialog} />
+          </DataTable.Col>
+        </DataTable>
+      </List>
+
+      <AssignPropertyDialog
+        record={selectedRecord}
+        onClose={handleCloseDialog}
+        options={options}
+        valueToId={valueToId}
+        isLoading={isLoadingProperties}
+        error={propertiesError}
       />
-      <ArrayInput source="hours.daily" label="Daily Hours">
-        <SimpleFormIterator inline>
-          <TextInput source="day" label="Day" />
-          <TextInput source="open" label="Open" />
-          <TextInput source="close" label="Close" />
-        </SimpleFormIterator>
-      </ArrayInput>
-      <NumberInput source="createdAt" label="Created At (epoch ms)" />
-    </SimpleForm>
-  </Create>
-);
-
-export const NumberEdit = () => (
-  <Edit>
-    <SimpleForm>
-      <ReferenceInput source="companyId" reference="companies">
-        <AutocompleteInput
-          label="Company"
-          optionText="name"
-          validate={[required()]}
-        />
-      </ReferenceInput>
-      <TextInput source="e164" label="Phone Number" validate={[required()]} />
-      <ReferenceInput source="assignedPropertyId" reference="properties">
-        <AutocompleteInput label="Assigned Property" optionText="name" />
-      </ReferenceInput>
-      <TextInput source="assignedQueue" label="Assigned Queue" />
-      <TextInput
-        source="hours.fallbackNumber"
-        label="Fallback Number"
-        placeholder="+1..."
-      />
-      <ArrayInput source="hours.daily" label="Daily Hours">
-        <SimpleFormIterator inline>
-          <TextInput source="day" label="Day" />
-          <TextInput source="open" label="Open" />
-          <TextInput source="close" label="Close" />
-        </SimpleFormIterator>
-      </ArrayInput>
-      <NumberInput source="createdAt" label="Created At (epoch ms)" />
-    </SimpleForm>
-  </Edit>
-);
-
-export const NumberShow = () => (
-  <Show>
-    <div className="flex flex-col gap-4">
-      <RecordField source="e164" label="Phone Number" />
-      <RecordField label="Company">
-        <ReferenceField reference="companies" source="companyId">
-          <TextField source="name" />
-        </ReferenceField>
-      </RecordField>
-      <RecordField label="Property">
-        <ReferenceField reference="properties" source="assignedPropertyId">
-          <TextField source="name" />
-        </ReferenceField>
-      </RecordField>
-      <RecordField source="assignedQueue" label="Assigned Queue" />
-      <RecordField source="hours.fallbackNumber" label="Fallback Number" />
-      <RecordField source="createdAt" label="Created">
-        <DateField source="createdAt" showTime />
-      </RecordField>
-    </div>
-  </Show>
-);
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- replace the Numbers resource with a Phone Numbers list view and remove creation/edit routes
- add a modal-driven property assignment workflow for phone numbers with clear unassigned states
- load available properties once and update numbers via the data provider when assignments change

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd53337f0c832cb927013202adcc15