### PR TITLE
fix: guard escalations drawer against stale detail loads

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as authHelpers from "../authHelpers.js";
 import type * as authStore from "../authStore.js";
 import type * as company from "../company.js";
 import type * as companyStore from "../companyStore.js";
+import type * as escalations from "../escalations.js";
 import type * as knowledgeBase from "../knowledgeBase.js";
 import type * as utils from "../utils.js";
 
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   authStore: typeof authStore;
   company: typeof company;
   companyStore: typeof companyStore;
+  escalations: typeof escalations;
   knowledgeBase: typeof knowledgeBase;
   utils: typeof utils;
 }>;

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -1,0 +1,279 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+
+const CLOSED_ESCALATION_STATUSES = new Set([
+  "closed",
+  "resolved",
+  "completed",
+  "dismissed",
+  "cancelled",
+]);
+
+type PropertySummary = {
+  id: string;
+  name: string;
+};
+
+type EscalationListItem = {
+  id: string;
+  propertyId: string;
+  propertyName: string;
+  priority: string;
+  status: string;
+  topic: string;
+  assigneeContact: string | null;
+  createdAt: number;
+};
+
+type EscalationDetail = EscalationListItem & {
+  summary: string | null;
+  resolvedAt: number | null;
+  transcriptRef: string | null;
+};
+
+type FilterResponse = {
+  properties: PropertySummary[];
+  priorities: string[];
+  statuses: string[];
+};
+
+const formatPropertySummary = (doc: Doc<"properties">): PropertySummary => ({
+  id: doc._id,
+  name: doc.name,
+});
+
+const formatListItem = (
+  escalation: Doc<"escalations">,
+  property: Doc<"properties"> | null,
+): EscalationListItem => ({
+  id: escalation._id,
+  propertyId: escalation.propertyId,
+  propertyName: property?.name ?? "Unknown property",
+  priority: escalation.priority,
+  status: escalation.status,
+  topic: escalation.topic,
+  assigneeContact: escalation.assigneeContact ?? null,
+  createdAt: escalation.createdAt,
+});
+
+export const listEscalations = query({
+  args: {
+    propertyId: v.optional(v.string()),
+    priority: v.optional(v.string()),
+    status: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<EscalationListItem[]> => {
+    const propertyFilter = args.propertyId
+      ? ctx.db.normalizeId("properties", args.propertyId)
+      : null;
+
+    let escalationQuery = ctx.db.query("escalations");
+    if (propertyFilter) {
+      escalationQuery = escalationQuery.withIndex("by_property_status", (q) =>
+        q.eq("propertyId", propertyFilter),
+      );
+    }
+
+    const escalations = await escalationQuery.collect();
+
+    const priorityFilter = args.priority?.trim().toLowerCase();
+    const statusFilter = args.status?.trim().toLowerCase();
+
+    const filtered = escalations.filter((escalation) => {
+      const priority = escalation.priority.trim().toLowerCase();
+      const status = escalation.status.trim().toLowerCase();
+      if (priorityFilter && priority !== priorityFilter) {
+        return false;
+      }
+      if (statusFilter && status !== statusFilter) {
+        return false;
+      }
+      return true;
+    });
+
+    const uniquePropertyIds = Array.from(
+      new Set(filtered.map((escalation) => escalation.propertyId)),
+    );
+    const propertyDocs = await Promise.all(
+      uniquePropertyIds.map((propertyId) => ctx.db.get(propertyId)),
+    );
+    const propertyMap = new Map<Id<"properties">, Doc<"properties"> | null>(
+      uniquePropertyIds.map((propertyId, index) => [
+        propertyId,
+        propertyDocs[index] ?? null,
+      ]),
+    );
+
+    return filtered
+      .map((escalation) =>
+        formatListItem(
+          escalation,
+          propertyMap.get(escalation.propertyId) ?? null,
+        ),
+      )
+      .sort((a, b) => b.createdAt - a.createdAt);
+  },
+});
+
+export const listFilters = query({
+  args: {},
+  handler: async (ctx): Promise<FilterResponse> => {
+    const [properties, escalations] = await Promise.all([
+      ctx.db.query("properties").collect(),
+      ctx.db.query("escalations").collect(),
+    ]);
+
+    const priorities = new Set<string>();
+    const statuses = new Set<string>();
+
+    for (const escalation of escalations) {
+      const priority = escalation.priority?.trim();
+      if (priority) {
+        priorities.add(priority);
+      }
+      const status = escalation.status?.trim();
+      if (status) {
+        statuses.add(status);
+      }
+    }
+
+    return {
+      properties: properties
+        .map(formatPropertySummary)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      priorities: Array.from(priorities).sort((a, b) => a.localeCompare(b)),
+      statuses: Array.from(statuses).sort((a, b) => a.localeCompare(b)),
+    };
+  },
+});
+
+export const getEscalation = query({
+  args: {
+    id: v.string(),
+  },
+  handler: async (ctx, args): Promise<EscalationDetail | null> => {
+    const escalationId = ctx.db.normalizeId("escalations", args.id);
+    if (!escalationId) {
+      return null;
+    }
+
+    const escalation = await ctx.db.get(escalationId);
+    if (!escalation) {
+      return null;
+    }
+
+    const property = await ctx.db.get(escalation.propertyId);
+
+    return {
+      ...formatListItem(escalation, property),
+      summary: escalation.summary ?? null,
+      resolvedAt: escalation.resolvedAt ?? null,
+      transcriptRef: escalation.transcriptRef ?? null,
+    };
+  },
+});
+
+export const assignContact = mutation({
+  args: {
+    id: v.string(),
+    contact: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<EscalationDetail | null> => {
+    const escalationId = ctx.db.normalizeId("escalations", args.id);
+    if (!escalationId) {
+      throw new Error("Escalation not found");
+    }
+
+    const escalation = await ctx.db.get(escalationId);
+    if (!escalation) {
+      throw new Error("Escalation not found");
+    }
+
+    const contact = args.contact?.trim() ?? "";
+    const normalizedContact = contact || undefined;
+
+    await ctx.db.patch(escalationId, {
+      assigneeContact: normalizedContact,
+    });
+
+    if (normalizedContact) {
+      await ctx.db.insert("notifications", {
+        escalationId,
+        companyId: escalation.companyId,
+        type: "escalation.assignment",
+        to: normalizedContact,
+        status: "pending",
+        attempts: 0,
+        createdAt: Date.now(),
+      });
+    }
+
+    const property = await ctx.db.get(escalation.propertyId);
+
+    return {
+      ...formatListItem(
+        { ...escalation, assigneeContact: normalizedContact },
+        property,
+      ),
+      summary: escalation.summary ?? null,
+      resolvedAt: escalation.resolvedAt ?? null,
+      transcriptRef: escalation.transcriptRef ?? null,
+    };
+  },
+});
+
+export const updateStatus = mutation({
+  args: {
+    id: v.string(),
+    status: v.string(),
+  },
+  handler: async (ctx, args): Promise<EscalationDetail | null> => {
+    const escalationId = ctx.db.normalizeId("escalations", args.id);
+    if (!escalationId) {
+      throw new Error("Escalation not found");
+    }
+
+    const escalation = await ctx.db.get(escalationId);
+    if (!escalation) {
+      throw new Error("Escalation not found");
+    }
+
+    const status = args.status.trim();
+    const isClosed = CLOSED_ESCALATION_STATUSES.has(status.toLowerCase());
+    const resolvedAt = isClosed ? Date.now() : undefined;
+
+    await ctx.db.patch(escalationId, {
+      status,
+      resolvedAt,
+    });
+
+    if (escalation.assigneeContact) {
+      await ctx.db.insert("notifications", {
+        escalationId,
+        companyId: escalation.companyId,
+        type: "escalation.status",
+        to: escalation.assigneeContact,
+        status: "pending",
+        attempts: 0,
+        createdAt: Date.now(),
+      });
+    }
+
+    const property = await ctx.db.get(escalation.propertyId);
+
+    return {
+      ...formatListItem(
+        {
+          ...escalation,
+          status,
+          resolvedAt: resolvedAt ?? escalation.resolvedAt,
+        },
+        property,
+      ),
+      summary: escalation.summary ?? null,
+      resolvedAt: resolvedAt ?? escalation.resolvedAt ?? null,
+      transcriptRef: escalation.transcriptRef ?? null,
+    };
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { UserCreate, UserEdit, UserList, UserShow } from "@/resources/users";
 import { PhoneNumberList } from "@/resources/numbers";
 import { SignupPage } from "@/components/admin/login-page";
 import KnowledgeBasePage from "@/pages/knowledge-base";
+import EscalationsPage from "@/pages/escalations";
 
 function App() {
   return (
@@ -60,6 +61,7 @@ function App() {
       />
       <CustomRoutes>
         <Route path="/knowledge-base" element={<KnowledgeBasePage />} />
+        <Route path="/escalations" element={<EscalationsPage />} />
       </CustomRoutes>
       <CustomRoutes noLayout>
         <Route

--- a/src/components/admin/app-sidebar.tsx
+++ b/src/components/admin/app-sidebar.tsx
@@ -21,7 +21,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BookOpen, House, List, Shell } from "lucide-react";
+import { AlertTriangle, BookOpen, House, List, Shell } from "lucide-react";
 
 export function AppSidebar() {
   const hasDashboard = useHasDashboard();
@@ -57,6 +57,7 @@ export function AppSidebar() {
                 <DashboardMenuItem onClick={handleClick} />
               ) : null}
               <KnowledgeBaseMenuItem onClick={handleClick} />
+              <EscalationsMenuItem onClick={handleClick} />
               {Object.keys(resources)
                 .filter((name) => resources[name].hasList)
                 .map((name) => (
@@ -105,6 +106,20 @@ export const KnowledgeBaseMenuItem = ({
         <Link to="/knowledge-base" onClick={onClick}>
           <BookOpen />
           Knowledge Base
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+};
+
+export const EscalationsMenuItem = ({ onClick }: { onClick?: () => void }) => {
+  const match = useMatch({ path: "/escalations", end: false });
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={!!match}>
+        <Link to="/escalations" onClick={onClick}>
+          <AlertTriangle />
+          Escalations
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>

--- a/src/pages/escalations.tsx
+++ b/src/pages/escalations.tsx
@@ -1,0 +1,691 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNotify } from "ra-core";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../convex/_generated/api";
+import { AlertTriangle, CheckCircle2, UserRound } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/admin/spinner";
+
+const PRIORITY_VARIANTS: Record<
+  string,
+  "default" | "secondary" | "destructive"
+> = {
+  high: "destructive",
+  urgent: "destructive",
+  medium: "default",
+  normal: "default",
+  low: "secondary",
+};
+
+const STATUS_VARIANTS: Record<string, "default" | "secondary" | "destructive"> =
+  {
+    open: "destructive",
+    pending: "default",
+    acknowledged: "default",
+    resolved: "secondary",
+    closed: "secondary",
+    completed: "secondary",
+  };
+
+type EscalationListItem = {
+  id: string;
+  propertyId: string;
+  propertyName: string;
+  priority: string;
+  status: string;
+  topic: string;
+  assigneeContact: string | null;
+  createdAt: number;
+};
+
+type EscalationDetail = EscalationListItem & {
+  summary: string | null;
+  resolvedAt: number | null;
+  transcriptRef: string | null;
+};
+
+type PropertySummary = {
+  id: string;
+  name: string;
+};
+
+type FilterResponse = {
+  properties: PropertySummary[];
+  priorities: string[];
+  statuses: string[];
+};
+
+const formatPriorityLabel = (priority: string) => {
+  if (!priority) return "Unspecified";
+  return priority.charAt(0).toUpperCase() + priority.slice(1).toLowerCase();
+};
+
+const formatStatusLabel = (status: string) => {
+  if (!status) return "Unknown";
+  return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+};
+
+const getBadgeVariant = (
+  value: string,
+  mapping: Record<string, "default" | "secondary" | "destructive">,
+) => {
+  const normalized = value.trim().toLowerCase();
+  return mapping[normalized] ?? "default";
+};
+
+const formatDateTime = (value: number | null) => {
+  if (!value) return "—";
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+const EMPTY_FILTERS: FilterResponse = {
+  properties: [],
+  priorities: [],
+  statuses: [],
+};
+
+const ALL_OPTION = "__all__";
+
+const EscalationsPage = () => {
+  const notify = useNotify();
+  const convexUrl = import.meta.env.VITE_CONVEX_URL;
+
+  if (!convexUrl) {
+    throw new Error(
+      "VITE_CONVEX_URL must be defined to manage escalation records.",
+    );
+  }
+
+  const convexClient = useMemo(
+    () => new ConvexHttpClient(convexUrl),
+    [convexUrl],
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const token = localStorage.getItem("better-auth:token");
+    if (token) {
+      convexClient.setAuth(token);
+    } else {
+      convexClient.clearAuth();
+    }
+  }, [convexClient]);
+
+  const [filters, setFilters] = useState({
+    propertyId: ALL_OPTION,
+    priority: ALL_OPTION,
+    status: ALL_OPTION,
+  });
+  const [filterOptions, setFilterOptions] =
+    useState<FilterResponse>(EMPTY_FILTERS);
+  const [loadingFilters, setLoadingFilters] = useState(false);
+
+  const [escalations, setEscalations] = useState<EscalationListItem[]>([]);
+  const [escalationsLoading, setEscalationsLoading] = useState(false);
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activeEscalationId, setActiveEscalationId] = useState<string | null>(
+    null,
+  );
+  const [activeEscalation, setActiveEscalation] =
+    useState<EscalationDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const detailRequestToken = useRef(0);
+
+  const [assignmentValue, setAssignmentValue] = useState("");
+  const [updatingAssignment, setUpdatingAssignment] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  const loadFilters = useCallback(async () => {
+    setLoadingFilters(true);
+    try {
+      const response = await convexClient.query(
+        api.escalations.listFilters,
+        {},
+      );
+      setFilterOptions(response ?? EMPTY_FILTERS);
+    } catch (error) {
+      console.error(error);
+      notify("Unable to load escalation filters", { type: "error" });
+      setFilterOptions(EMPTY_FILTERS);
+    } finally {
+      setLoadingFilters(false);
+    }
+  }, [convexClient, notify]);
+
+  useEffect(() => {
+    void loadFilters();
+  }, [loadFilters]);
+
+  const loadEscalations = useCallback(async () => {
+    setEscalationsLoading(true);
+    try {
+      const response = await convexClient.query(
+        api.escalations.listEscalations,
+        {
+          propertyId:
+            filters.propertyId === ALL_OPTION ? undefined : filters.propertyId,
+          priority:
+            filters.priority === ALL_OPTION ? undefined : filters.priority,
+          status: filters.status === ALL_OPTION ? undefined : filters.status,
+        },
+      );
+      setEscalations(response ?? []);
+    } catch (error) {
+      console.error(error);
+      notify("Unable to load escalations", { type: "error" });
+      setEscalations([]);
+    } finally {
+      setEscalationsLoading(false);
+    }
+  }, [
+    convexClient,
+    filters.propertyId,
+    filters.priority,
+    filters.status,
+    notify,
+  ]);
+
+  useEffect(() => {
+    void loadEscalations();
+  }, [loadEscalations]);
+
+  const handleOpenDrawer = useCallback(
+    async (escalationId: string) => {
+      setDrawerOpen(true);
+      setActiveEscalationId(escalationId);
+      const requestToken = detailRequestToken.current + 1;
+      detailRequestToken.current = requestToken;
+      setDetailLoading(true);
+      try {
+        const detail = await convexClient.query(api.escalations.getEscalation, {
+          id: escalationId,
+        });
+        if (detailRequestToken.current !== requestToken) {
+          return;
+        }
+        setActiveEscalation(detail);
+        setAssignmentValue(detail?.assigneeContact ?? "");
+      } catch (error) {
+        console.error(error);
+        notify("Unable to load escalation details", { type: "error" });
+        if (detailRequestToken.current !== requestToken) {
+          return;
+        }
+        setActiveEscalation(null);
+        setAssignmentValue("");
+      } finally {
+        if (detailRequestToken.current === requestToken) {
+          setDetailLoading(false);
+        }
+      }
+    },
+    [convexClient, notify],
+  );
+
+  const closeDrawer = useCallback(() => {
+    detailRequestToken.current += 1;
+    setDrawerOpen(false);
+    setActiveEscalationId(null);
+    setActiveEscalation(null);
+    setAssignmentValue("");
+    setDetailLoading(false);
+  }, []);
+
+  const handleAssignmentUpdate = useCallback(async () => {
+    if (!activeEscalationId) return;
+    setUpdatingAssignment(true);
+    try {
+      const updated = await convexClient.mutation(
+        api.escalations.assignContact,
+        {
+          id: activeEscalationId,
+          contact: assignmentValue.trim() || undefined,
+        },
+      );
+      setActiveEscalation(updated);
+      notify("Escalation assignee updated", { type: "success" });
+      void loadEscalations();
+    } catch (error) {
+      console.error(error);
+      notify("Unable to update assignee", { type: "error" });
+    } finally {
+      setUpdatingAssignment(false);
+    }
+  }, [
+    activeEscalationId,
+    assignmentValue,
+    convexClient,
+    loadEscalations,
+    notify,
+  ]);
+
+  const handleStatusUpdate = useCallback(
+    async (status: string) => {
+      if (!activeEscalationId) return;
+      setUpdatingStatus(true);
+      try {
+        const updated = await convexClient.mutation(
+          api.escalations.updateStatus,
+          {
+            id: activeEscalationId,
+            status,
+          },
+        );
+        setActiveEscalation(updated);
+        notify("Escalation status updated", { type: "success" });
+        void loadEscalations();
+      } catch (error) {
+        console.error(error);
+        notify("Unable to update status", { type: "error" });
+      } finally {
+        setUpdatingStatus(false);
+      }
+    },
+    [activeEscalationId, convexClient, loadEscalations, notify],
+  );
+
+  const handleFilterChange =
+    (key: "propertyId" | "priority" | "status") => (value: string) => {
+      setFilters((prev) => ({
+        ...prev,
+        [key]: value,
+      }));
+    };
+
+  const clearFilters = () => {
+    setFilters({
+      propertyId: ALL_OPTION,
+      priority: ALL_OPTION,
+      status: ALL_OPTION,
+    });
+  };
+
+  const hasActiveFilters =
+    filters.propertyId !== ALL_OPTION ||
+    filters.priority !== ALL_OPTION ||
+    filters.status !== ALL_OPTION;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>Escalations</CardTitle>
+            <CardDescription>
+              Track open issues, assign follow-up contacts, and resolve
+              escalations.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={clearFilters}
+              disabled={escalationsLoading || !hasActiveFilters}
+            >
+              Reset filters
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="property-filter">Property</Label>
+              <Select
+                value={filters.propertyId}
+                onValueChange={handleFilterChange("propertyId")}
+                disabled={loadingFilters}
+              >
+                <SelectTrigger id="property-filter">
+                  <SelectValue placeholder="All properties" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_OPTION}>All properties</SelectItem>
+                  {filterOptions.properties.map((property) => (
+                    <SelectItem key={property.id} value={property.id}>
+                      {property.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="priority-filter">Priority</Label>
+              <Select
+                value={filters.priority}
+                onValueChange={handleFilterChange("priority")}
+                disabled={loadingFilters}
+              >
+                <SelectTrigger id="priority-filter">
+                  <SelectValue placeholder="All priorities" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_OPTION}>All priorities</SelectItem>
+                  {filterOptions.priorities.map((priority) => (
+                    <SelectItem key={priority} value={priority}>
+                      {formatPriorityLabel(priority)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="status-filter">Status</Label>
+              <Select
+                value={filters.status}
+                onValueChange={handleFilterChange("status")}
+                disabled={loadingFilters}
+              >
+                <SelectTrigger id="status-filter">
+                  <SelectValue placeholder="All statuses" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_OPTION}>All statuses</SelectItem>
+                  {filterOptions.statuses.map((status) => (
+                    <SelectItem key={status} value={status}>
+                      {formatStatusLabel(status)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Topic</TableHead>
+                  <TableHead>Property</TableHead>
+                  <TableHead className="hidden sm:table-cell">
+                    Priority
+                  </TableHead>
+                  <TableHead className="hidden sm:table-cell">Status</TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    Assignee
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    Created
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {escalationsLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-12 text-center">
+                      <Spinner />
+                    </TableCell>
+                  </TableRow>
+                ) : escalations.length ? (
+                  escalations.map((escalation) => (
+                    <TableRow
+                      key={escalation.id}
+                      className="hover:bg-muted/60 cursor-pointer"
+                      onClick={() => void handleOpenDrawer(escalation.id)}
+                    >
+                      <TableCell className="max-w-[240px] font-medium">
+                        {escalation.topic}
+                      </TableCell>
+                      <TableCell>{escalation.propertyName}</TableCell>
+                      <TableCell className="hidden sm:table-cell">
+                        <Badge
+                          variant={getBadgeVariant(
+                            escalation.priority,
+                            PRIORITY_VARIANTS,
+                          )}
+                        >
+                          {formatPriorityLabel(escalation.priority)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell">
+                        <Badge
+                          variant={getBadgeVariant(
+                            escalation.status,
+                            STATUS_VARIANTS,
+                          )}
+                        >
+                          {formatStatusLabel(escalation.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        {escalation.assigneeContact ? (
+                          <span className="inline-flex items-center gap-1">
+                            <UserRound className="size-4" />
+                            {escalation.assigneeContact}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">
+                            Unassigned
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        {formatDateTime(escalation.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={6}
+                      className="text-muted-foreground py-12 text-center"
+                    >
+                      No escalations match the selected filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Drawer
+        open={drawerOpen}
+        onOpenChange={(open) => (!open ? closeDrawer() : undefined)}
+      >
+        <DrawerContent className="max-h-[90vh] overflow-y-auto">
+          <DrawerHeader className="space-y-2 text-left">
+            <DrawerTitle>
+              {activeEscalation?.topic ?? "Escalation details"}
+            </DrawerTitle>
+            <DrawerDescription>
+              Review the conversation summary and take action on this
+              escalation.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="space-y-6 px-6 pb-6">
+            {detailLoading ? (
+              <div className="flex justify-center py-12">
+                <Spinner />
+              </div>
+            ) : activeEscalation ? (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Property
+                    </Label>
+                    <div className="text-sm font-medium">
+                      {activeEscalation.propertyName}
+                    </div>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Priority
+                    </Label>
+                    <Badge
+                      variant={getBadgeVariant(
+                        activeEscalation.priority,
+                        PRIORITY_VARIANTS,
+                      )}
+                    >
+                      {formatPriorityLabel(activeEscalation.priority)}
+                    </Badge>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Status
+                    </Label>
+                    <Badge
+                      variant={getBadgeVariant(
+                        activeEscalation.status,
+                        STATUS_VARIANTS,
+                      )}
+                    >
+                      {formatStatusLabel(activeEscalation.status)}
+                    </Badge>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Created at
+                    </Label>
+                    <div className="text-sm">
+                      {formatDateTime(activeEscalation.createdAt)}
+                    </div>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Resolved at
+                    </Label>
+                    <div className="text-sm">
+                      {formatDateTime(activeEscalation.resolvedAt)}
+                    </div>
+                  </div>
+                </div>
+                <Separator />
+                <div className="space-y-2">
+                  <Label className="text-muted-foreground text-xs uppercase">
+                    Summary
+                  </Label>
+                  <p className="text-sm whitespace-pre-line">
+                    {activeEscalation.summary ?? "No summary provided."}
+                  </p>
+                </div>
+                {activeEscalation.transcriptRef ? (
+                  <div className="space-y-1">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Transcript Reference
+                    </Label>
+                    <p className="text-muted-foreground text-sm">
+                      {activeEscalation.transcriptRef}
+                    </p>
+                  </div>
+                ) : null}
+                <Separator />
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="assignment"
+                      className="text-muted-foreground text-xs uppercase"
+                    >
+                      Assign contact
+                    </Label>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <Input
+                        id="assignment"
+                        value={assignmentValue}
+                        onChange={(event) =>
+                          setAssignmentValue(event.target.value)
+                        }
+                        placeholder="Email or phone number"
+                      />
+                      <Button
+                        onClick={() => void handleAssignmentUpdate()}
+                        disabled={updatingAssignment}
+                      >
+                        {updatingAssignment ? "Saving" : "Save"}
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="text-muted-foreground text-xs uppercase">
+                      Update status
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.statuses.map((status) => (
+                        <Button
+                          key={status}
+                          variant={
+                            activeEscalation.status.toLowerCase() ===
+                            status.toLowerCase()
+                              ? "default"
+                              : "outline"
+                          }
+                          onClick={() => void handleStatusUpdate(status)}
+                          disabled={updatingStatus}
+                        >
+                          {formatStatusLabel(status)}
+                        </Button>
+                      ))}
+                      {!filterOptions.statuses.some(
+                        (status) =>
+                          status.toLowerCase() ===
+                          activeEscalation.status.toLowerCase(),
+                      ) ? (
+                        <Button variant="outline" disabled>
+                          {formatStatusLabel(activeEscalation.status)}
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="text-muted-foreground flex flex-col items-center gap-2 py-12 text-center">
+                <AlertTriangle className="size-6" />
+                <span>Escalation not found.</span>
+              </div>
+            )}
+          </div>
+          <DrawerFooter className="text-muted-foreground flex flex-col items-start gap-2 border-t px-6 py-4 text-sm">
+            <div className="flex items-center gap-2 text-xs uppercase">
+              <CheckCircle2 className="size-4" />
+              Escalation updates notify assigned contacts automatically.
+            </div>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};
+
+export default EscalationsPage;
+export { EscalationsPage };


### PR DESCRIPTION
## Summary
- guard the escalations drawer state by tracking the latest detail request
- ignore stale detail fetches and clear loading when the drawer closes to avoid overwriting newer selections

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dd745d4bf8832cb1549d737281744e