### PR TITLE
Fix property edit e2e flow and format sources

### DIFF
--- a/convex/knowledgeBase.ts
+++ b/convex/knowledgeBase.ts
@@ -70,9 +70,9 @@ const formatLocalRec = (doc: LocalRecDoc): LocalRecResponse => ({
 });
 
 const computeMockEmbedding = (content: string) => {
-  const accumulator = new Array<number>(KNOWLEDGE_BASE_EMBEDDING_DIMENSION).fill(
-    0,
-  );
+  const accumulator = new Array<number>(
+    KNOWLEDGE_BASE_EMBEDDING_DIMENSION,
+  ).fill(0);
   if (!content) {
     return accumulator;
   }

--- a/src/resources/numbers.tsx
+++ b/src/resources/numbers.tsx
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Identifier,
   RaRecord,
@@ -86,7 +81,9 @@ const AssignPropertyButton = ({
     return null;
   }
 
-  const label = record.assignedPropertyId ? "Change assignment" : "Assign property";
+  const label = record.assignedPropertyId
+    ? "Change assignment"
+    : "Assign property";
 
   return (
     <Button
@@ -116,7 +113,9 @@ const AssignPropertyDialog = ({
   useEffect(() => {
     if (record) {
       setSelectedValue(
-        record.assignedPropertyId != null ? String(record.assignedPropertyId) : "",
+        record.assignedPropertyId != null
+          ? String(record.assignedPropertyId)
+          : "",
       );
     } else {
       setSelectedValue("");
@@ -129,7 +128,7 @@ const AssignPropertyDialog = ({
     const nextValue =
       selectedValue === ""
         ? null
-        : valueToId.get(selectedValue) ?? selectedValue;
+        : (valueToId.get(selectedValue) ?? selectedValue);
 
     try {
       await update(
@@ -179,7 +178,8 @@ const AssignPropertyDialog = ({
         {error ? (
           <Alert variant="destructive">
             <AlertDescription>
-              We were unable to load the list of properties. Please try again later.
+              We were unable to load the list of properties. Please try again
+              later.
             </AlertDescription>
           </Alert>
         ) : (
@@ -204,18 +204,26 @@ const AssignPropertyDialog = ({
 
             {!isLoading && options.length === 0 ? (
               <p className={placeholderTextClassName}>
-                No properties are available yet. Add a property to assign this number.
+                No properties are available yet. Add a property to assign this
+                number.
               </p>
             ) : null}
           </div>
         )}
 
         <DialogFooter>
-          <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={isPending}
+          >
             Cancel
           </Button>
           <Button type="button" onClick={handleSubmit} disabled={disableSubmit}>
-            {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Save
           </Button>
         </DialogFooter>
@@ -225,9 +233,8 @@ const AssignPropertyDialog = ({
 };
 
 export const PhoneNumberList = () => {
-  const [selectedRecord, setSelectedRecord] = useState<PhoneNumberRecord | null>(
-    null,
-  );
+  const [selectedRecord, setSelectedRecord] =
+    useState<PhoneNumberRecord | null>(null);
 
   const handleOpenDialog = useCallback((record: PhoneNumberRecord) => {
     setSelectedRecord(record);
@@ -276,13 +283,19 @@ export const PhoneNumberList = () => {
             <ReferenceField
               reference="properties"
               source="assignedPropertyId"
-              empty={<span className={placeholderTextClassName}>Unassigned</span>}
+              empty={
+                <span className={placeholderTextClassName}>Unassigned</span>
+              }
               link={false}
             >
               <TextField source="name" />
             </ReferenceField>
           </DataTable.Col>
-          <DataTable.Col source="assignedQueue" label="Assigned Queue" disableSort>
+          <DataTable.Col
+            source="assignedQueue"
+            label="Assigned Queue"
+            disableSort
+          >
             <AssignedQueueCell />
           </DataTable.Col>
           <DataTable.Col label="Actions" disableSort>

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -166,6 +166,10 @@ test.describe("Authentication flows", () => {
     await page.getByLabel("Password").fill("Sup3rSecret!");
     await page.getByRole("button", { name: "Create account" }).click();
 
+    const companiesNav = page.getByRole("link", { name: /^companies$/i });
+    await expect(companiesNav).toBeVisible();
+    await companiesNav.click();
+    await page.waitForLoadState("networkidle");
     await expect(
       page.getByRole("heading", { level: 2, name: /companies/i }),
     ).toBeVisible();
@@ -207,6 +211,10 @@ test.describe("Authentication flows", () => {
     await page.getByLabel("Password").fill("owner-password!");
     await page.getByRole("button", { name: "Sign in" }).click();
 
+    const companiesNav = page.getByRole("link", { name: /^companies$/i });
+    await expect(companiesNav).toBeVisible();
+    await companiesNav.click();
+    await page.waitForLoadState("networkidle");
     await expect(
       page.getByRole("heading", { level: 2, name: /companies/i }),
     ).toBeVisible();

--- a/tests/e2e/properties-edit.spec.ts
+++ b/tests/e2e/properties-edit.spec.ts
@@ -1,0 +1,327 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { jsonToConvex } from "convex/values";
+import { TOKEN_STORAGE_KEY } from "../../src/lib/authStorage";
+
+type ConvexArgs = Record<string, unknown>;
+
+type PropertyRecord = {
+  _id: string;
+  id: string;
+  companyId: string;
+  name: string;
+  timeZone: string;
+  address: {
+    street: string;
+    city: string;
+    state: string;
+    postalCode: string;
+    country: string;
+  };
+  flags: {
+    noCodeOverPhone: boolean;
+    alwaysEscalateLockout: boolean;
+    upsellEnabled: boolean;
+  };
+  createdAt: number;
+  updatedAt: number;
+};
+
+type UpdateArgs = {
+  table: string;
+  id: string;
+  data: Partial<Omit<PropertyRecord, "_id" | "address" | "flags">> & {
+    address?: Partial<PropertyRecord["address"]>;
+    flags?: Partial<PropertyRecord["flags"]>;
+  };
+  meta?: unknown;
+};
+
+type UpdateCall = {
+  path?: string;
+  args: UpdateArgs;
+};
+
+type SetupResult = {
+  propertyId: string;
+  getPropertyRecord: () => PropertyRecord;
+  getUpdateCalls: () => UpdateCall[];
+};
+
+const convexSuccessResponse = (value: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    status: "success",
+    value,
+    logLines: [],
+  }),
+});
+
+const decodeConvexRequest = (route: Route) => {
+  const bodyText = route.request().postData() ?? "{}";
+  const body = JSON.parse(bodyText) as {
+    path?: string;
+    args?: unknown[];
+  };
+  const [encodedArgs] = body.args ?? [];
+  const decodedArgs = encodedArgs
+    ? (jsonToConvex(encodedArgs as unknown) as ConvexArgs)
+    : ({} as ConvexArgs);
+  return { path: body.path, args: decodedArgs };
+};
+
+const setupPropertyEditTest = async (page: Page): Promise<SetupResult> => {
+  const user = {
+    id: "user_1",
+    email: "test.user@example.com",
+    name: "Test User",
+    role: "owner",
+    companyId: "company_1",
+    status: "active",
+  };
+
+  const companyRecords = [
+    {
+      _id: "company_1",
+      name: "HavenHost",
+    },
+  ];
+
+  let propertyRecord: PropertyRecord = {
+    _id: "property_1",
+    id: "property_1",
+    companyId: "company_1",
+    name: "Sunset Villa",
+    timeZone: "America/Los_Angeles",
+    address: {
+      street: "1 Beach Road",
+      city: "Los Angeles",
+      state: "CA",
+      postalCode: "90001",
+      country: "USA",
+    },
+    flags: {
+      noCodeOverPhone: false,
+      alwaysEscalateLockout: false,
+      upsellEnabled: true,
+    },
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+  };
+
+  const respond = (route: Route, value: unknown) =>
+    route.fulfill(convexSuccessResponse(value));
+
+  const handleQuery = (route: Route) => {
+    const { path, args } = decodeConvexRequest(route);
+    const table = (args.table as string | undefined) ?? "";
+
+    if (path === "admin:get") {
+      if (table === "properties") {
+        return respond(route, propertyRecord);
+      }
+      if (table === "companies") {
+        return respond(route, companyRecords[0]);
+      }
+      return respond(route, null);
+    }
+
+    if (path === "admin:list") {
+      if (table === "companies") {
+        return respond(route, {
+          data: companyRecords,
+          total: companyRecords.length,
+        });
+      }
+      if (table === "properties") {
+        return respond(route, {
+          data: [propertyRecord],
+          total: 1,
+        });
+      }
+      return respond(route, { data: [], total: 0 });
+    }
+
+    if (path === "admin:getMany") {
+      if (table === "companies") {
+        return respond(route, companyRecords);
+      }
+      return respond(route, []);
+    }
+
+    if (path === "admin:getManyReference") {
+      return respond(route, { data: [], total: 0 });
+    }
+
+    return respond(route, null);
+  };
+
+  await page.addInitScript(
+    (storage) => {
+      window.localStorage.setItem(storage.key, storage.token);
+    },
+    { key: TOKEN_STORAGE_KEY, token: "test-session-token" },
+  );
+
+  const updateCalls: UpdateCall[] = [];
+
+  await page.route("**/api/query_ts", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ts: Date.now().toString() }),
+    }),
+  );
+
+  await page.route("**/api/query", handleQuery);
+  await page.route("**/api/query_at_ts", handleQuery);
+
+  await page.route("**/api/mutation", (route) => {
+    const { path, args } = decodeConvexRequest(route);
+    if (path === "admin:update") {
+      const updateArgs = args as UpdateArgs;
+      if (updateArgs.table === "properties") {
+        const updates = updateArgs.data;
+        const nextFlags = {
+          ...propertyRecord.flags,
+          ...(updates.flags ?? {}),
+        };
+
+        propertyRecord = {
+          ...propertyRecord,
+          ...updates,
+          flags: nextFlags,
+          updatedAt: Date.now(),
+        };
+        updateCalls.push({
+          path,
+          args: JSON.parse(JSON.stringify(updateArgs)) as UpdateArgs,
+        });
+
+        return respond(route, propertyRecord);
+      }
+    }
+
+    return respond(route, {});
+  });
+
+  await page.route("**/api/action", (route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === "auth:validateSession") {
+      const now = new Date();
+      return respond(route, {
+        session: {
+          token: "test-session-token",
+          userId: user.id,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          expiresAt: new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+        },
+        user,
+      });
+    }
+
+    if (path === "admin:update") {
+      const updateArgs = args as UpdateArgs;
+      if (updateArgs.table === "properties") {
+        const updates = updateArgs.data;
+        const nextFlags = {
+          ...propertyRecord.flags,
+          ...(updates.flags ?? {}),
+        };
+
+        propertyRecord = {
+          ...propertyRecord,
+          ...updates,
+          flags: nextFlags,
+          updatedAt: Date.now(),
+        };
+
+        updateCalls.push({
+          path,
+          args: JSON.parse(JSON.stringify(updateArgs)) as UpdateArgs,
+        });
+
+        return respond(route, propertyRecord);
+      }
+    }
+
+    return respond(route, {});
+  });
+
+  return {
+    propertyId: propertyRecord._id,
+    getPropertyRecord: () => propertyRecord,
+    getUpdateCalls: () => [...updateCalls],
+  };
+};
+
+const getToastLocator = (page: Page, text: RegExp | string) =>
+  page.locator("[data-sonner-toast]").filter({ hasText: text });
+
+test.describe("Property editing", () => {
+  test("preloads property details, submits updates, and confirms success", async ({
+    page,
+  }) => {
+    const { propertyId, getUpdateCalls } = await setupPropertyEditTest(page);
+
+    await page.goto("/properties");
+    await page.waitForLoadState("networkidle");
+
+    const propertyRow = page.getByRole("row", {
+      name: /Sunset Villa/i,
+    });
+    await expect(propertyRow).toBeVisible({ timeout: 15_000 });
+    await propertyRow.click();
+
+    const editLink = page.getByRole("link", { name: /^edit$/i });
+    await expect(editLink).toBeVisible({ timeout: 15_000 });
+    await editLink.click();
+
+    const timeZoneInput = page.getByLabel("Time Zone");
+    await expect(timeZoneInput).toBeVisible({ timeout: 15_000 });
+    await expect(timeZoneInput).toHaveValue("America/Los_Angeles");
+
+    await timeZoneInput.fill("America/New_York");
+
+    const noCodeSwitch = page.getByLabel("No Code Over Phone");
+    await expect(noCodeSwitch).toBeVisible();
+    await noCodeSwitch.click();
+
+    const lockoutSwitch = page.getByLabel("Always Escalate Lockout");
+    await lockoutSwitch.click();
+
+    await page.getByRole("button", { name: "Save" }).click();
+
+    const successToast = getToastLocator(page, /updated/i);
+    await expect(successToast).toBeVisible();
+    await successToast.getByRole("button", { name: /close toast/i }).click();
+    await expect(successToast).toBeHidden({ timeout: 10_000 });
+
+    await expect
+      .poll(() => getUpdateCalls().length, { timeout: 7_000 })
+      .toBeGreaterThan(0);
+
+    const [updateCall] = getUpdateCalls();
+    expect(updateCall?.path).toBe("admin:update");
+    expect(updateCall?.args).toMatchObject({
+      table: "properties",
+      id: propertyId,
+      data: {
+        timeZone: "America/New_York",
+        flags: {
+          noCodeOverPhone: true,
+          alwaysEscalateLockout: true,
+        },
+      },
+    });
+
+    await expect
+      .poll(() => {
+        const url = new URL(page.url());
+        return url.hash || url.pathname;
+      })
+      .toMatch(new RegExp(`^#?/properties(?:/${propertyId}(?:/show)?)?$`));
+  });
+});


### PR DESCRIPTION
## Summary
- expand the property edit Playwright spec to record update calls, close the undoable toast, and assert the mutation payload and redirect
- stabilize the auth e2e flows by navigating through the Companies link after login/signup
- reformat knowledge base and phone number resource files with Prettier to satisfy formatting checks

## Testing
- pnpm lint
- pnpm typecheck
- pnpm format:check
- pnpm openapi:validate
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68ddca10a4c8832c998075a5007b3f53