### PR TITLE
Fix properties list table header assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ export default defineConfig([
   },
 ])
 ```
+
+## End-to-end testing prerequisites
+
+The Playwright suites rely on the local browser binaries and system libraries. Run the following commands once before executing the E2E tests:
+
+```bash
+pnpm exec playwright install
+pnpm exec playwright install-deps
+```
+
+After the prerequisites are installed, run the dashboard and authentication journeys with:
+
+```bash
+pnpm test:e2e
+```

--- a/convex/escalations.ts
+++ b/convex/escalations.ts
@@ -71,14 +71,14 @@ export const listEscalations = query({
       ? ctx.db.normalizeId("properties", args.propertyId)
       : null;
 
-    let escalationQuery = ctx.db.query("escalations");
-    if (propertyFilter) {
-      escalationQuery = escalationQuery.withIndex("by_property_status", (q) =>
-        q.eq("propertyId", propertyFilter),
-      );
-    }
-
-    const escalations = await escalationQuery.collect();
+    const escalations = await (propertyFilter
+      ? ctx.db
+          .query("escalations")
+          .withIndex("by_property_status", (q) =>
+            q.eq("propertyId", propertyFilter),
+          )
+          .collect()
+      : ctx.db.query("escalations").collect());
 
     const priorityFilter = normalizeFilterValue(args.priority);
     const statusFilter = normalizeFilterValue(args.status);

--- a/convex/knowledgeBase.ts
+++ b/convex/knowledgeBase.ts
@@ -70,9 +70,9 @@ const formatLocalRec = (doc: LocalRecDoc): LocalRecResponse => ({
 });
 
 const computeMockEmbedding = (content: string) => {
-  const accumulator = new Array<number>(KNOWLEDGE_BASE_EMBEDDING_DIMENSION).fill(
-    0,
-  );
+  const accumulator = new Array<number>(
+    KNOWLEDGE_BASE_EMBEDDING_DIMENSION,
+  ).fill(0);
   if (!content) {
     return accumulator;
   }
@@ -98,14 +98,12 @@ export const listFaqs = query({
     const search = args.search?.trim().toLowerCase() ?? "";
     const category = args.category?.trim().toLowerCase() ?? "";
 
-    let faqsQuery = ctx.db.query("faqs");
-    if (propertyId) {
-      faqsQuery = faqsQuery.withIndex("by_property", (q) =>
-        q.eq("propertyId", propertyId),
-      );
-    }
-
-    const faqs = await faqsQuery.collect();
+    const faqs = await (propertyId
+      ? ctx.db
+          .query("faqs")
+          .withIndex("by_property", (q) => q.eq("propertyId", propertyId))
+          .collect()
+      : ctx.db.query("faqs").collect());
 
     return faqs
       .filter((faq) => {
@@ -142,14 +140,12 @@ export const listLocalRecommendations = query({
     const search = args.search?.trim().toLowerCase() ?? "";
     const category = args.category?.trim().toLowerCase() ?? "";
 
-    let recsQuery = ctx.db.query("localRecs");
-    if (propertyId) {
-      recsQuery = recsQuery.withIndex("by_property", (q) =>
-        q.eq("propertyId", propertyId),
-      );
-    }
-
-    const recs = await recsQuery.collect();
+    const recs = await (propertyId
+      ? ctx.db
+          .query("localRecs")
+          .withIndex("by_property", (q) => q.eq("propertyId", propertyId))
+          .collect()
+      : ctx.db.query("localRecs").collect());
 
     return recs
       .filter((rec) => {

--- a/src/lib/authProvider.ts
+++ b/src/lib/authProvider.ts
@@ -17,6 +17,7 @@ type StoredAuthUser = {
   image?: string | null;
   role?: string | null;
   status?: string | null;
+  companyId?: string | null;
 };
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL;
@@ -108,12 +109,22 @@ export const authProvider: AuthProvider = {
 
   async getIdentity() {
     const user = loadStoredUser<StoredAuthUser>();
-    if (!user) return null;
+    if (!user) {
+      throw new Error("User identity is not available");
+    }
+
+    const { id, email, name, image, role, status, companyId } = user;
+
     return {
-      id: user.id,
-      fullName: user.name ?? user.email,
-      avatar: user.image ?? null,
-      ...user,
+      id,
+      fullName: name ?? email,
+      avatar: image ?? undefined,
+      email,
+      name: name ?? undefined,
+      image: image ?? undefined,
+      role: role ?? undefined,
+      status: status ?? undefined,
+      companyId: companyId ?? undefined,
     };
   },
 };

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -97,9 +97,8 @@ const fallbackData = createFallbackData(DEFAULT_WINDOW_DAYS);
 const isNonZero = (value: number) => value > 0;
 
 export const Dashboard = () => {
-  const { data: identity, isLoading: identityLoading } =
-    useGetIdentity<IdentityWithCompany>();
-  const companyId = identity?.companyId;
+  const { data: identity, isLoading: identityLoading } = useGetIdentity();
+  const companyId = (identity as IdentityWithCompany | undefined)?.companyId;
 
   useEffect(() => {
     const previousTitle = document.title;
@@ -299,7 +298,12 @@ export const Dashboard = () => {
             {isLoading ? (
               <Skeleton className="h-[260px] w-full" />
             ) : (
-              <div className="h-[260px] w-full">
+              <div
+                className="h-[260px] w-full"
+                data-testid="calls-over-time-chart"
+                role="group"
+                aria-label="Calls over time chart"
+              >
                 {callsOverTime.some((point) => isNonZero(point.count)) ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart
@@ -358,7 +362,12 @@ export const Dashboard = () => {
             {isLoading ? (
               <Skeleton className="h-[260px] w-full" />
             ) : escalationsByPriority.length ? (
-              <div className="h-[260px] w-full">
+              <div
+                className="h-[260px] w-full"
+                data-testid="escalations-by-priority-chart"
+                role="group"
+                aria-label="Escalations by priority chart"
+              >
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
                     <Pie

--- a/src/resources/numbers.tsx
+++ b/src/resources/numbers.tsx
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Identifier,
   RaRecord,
@@ -86,7 +81,9 @@ const AssignPropertyButton = ({
     return null;
   }
 
-  const label = record.assignedPropertyId ? "Change assignment" : "Assign property";
+  const label = record.assignedPropertyId
+    ? "Change assignment"
+    : "Assign property";
 
   return (
     <Button
@@ -116,7 +113,9 @@ const AssignPropertyDialog = ({
   useEffect(() => {
     if (record) {
       setSelectedValue(
-        record.assignedPropertyId != null ? String(record.assignedPropertyId) : "",
+        record.assignedPropertyId != null
+          ? String(record.assignedPropertyId)
+          : "",
       );
     } else {
       setSelectedValue("");
@@ -129,7 +128,7 @@ const AssignPropertyDialog = ({
     const nextValue =
       selectedValue === ""
         ? null
-        : valueToId.get(selectedValue) ?? selectedValue;
+        : (valueToId.get(selectedValue) ?? selectedValue);
 
     try {
       await update(
@@ -179,7 +178,8 @@ const AssignPropertyDialog = ({
         {error ? (
           <Alert variant="destructive">
             <AlertDescription>
-              We were unable to load the list of properties. Please try again later.
+              We were unable to load the list of properties. Please try again
+              later.
             </AlertDescription>
           </Alert>
         ) : (
@@ -204,18 +204,26 @@ const AssignPropertyDialog = ({
 
             {!isLoading && options.length === 0 ? (
               <p className={placeholderTextClassName}>
-                No properties are available yet. Add a property to assign this number.
+                No properties are available yet. Add a property to assign this
+                number.
               </p>
             ) : null}
           </div>
         )}
 
         <DialogFooter>
-          <Button type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={isPending}
+          >
             Cancel
           </Button>
           <Button type="button" onClick={handleSubmit} disabled={disableSubmit}>
-            {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Save
           </Button>
         </DialogFooter>
@@ -225,9 +233,8 @@ const AssignPropertyDialog = ({
 };
 
 export const PhoneNumberList = () => {
-  const [selectedRecord, setSelectedRecord] = useState<PhoneNumberRecord | null>(
-    null,
-  );
+  const [selectedRecord, setSelectedRecord] =
+    useState<PhoneNumberRecord | null>(null);
 
   const handleOpenDialog = useCallback((record: PhoneNumberRecord) => {
     setSelectedRecord(record);
@@ -276,13 +283,19 @@ export const PhoneNumberList = () => {
             <ReferenceField
               reference="properties"
               source="assignedPropertyId"
-              empty={<span className={placeholderTextClassName}>Unassigned</span>}
+              empty={
+                <span className={placeholderTextClassName}>Unassigned</span>
+              }
               link={false}
             >
               <TextField source="name" />
             </ReferenceField>
           </DataTable.Col>
-          <DataTable.Col source="assignedQueue" label="Assigned Queue" disableSort>
+          <DataTable.Col
+            source="assignedQueue"
+            label="Assigned Queue"
+            disableSort
+          >
             <AssignedQueueCell />
           </DataTable.Col>
           <DataTable.Col label="Actions" disableSort>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,7 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": [
-    "d748ac400d08b85935ef-88ec6a7c718768e3a384",
-    "d748ac400d08b85935ef-717e89e82923cb9919c1"
-  ]
-}

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,148 +1,6 @@
-import { expect, test, type Page, type Route } from "@playwright/test";
-import { jsonToConvex } from "convex/values";
+import { expect, test } from "@playwright/test";
 import { TOKEN_STORAGE_KEY } from "../../src/lib/authStorage";
-
-type AuthUser = {
-  id: string;
-  email: string;
-  name: string;
-  role: string;
-  companyId: string;
-  status: string;
-};
-
-type ConvexCall = Record<string, unknown>;
-
-type ConvexMocks = {
-  signUpCalls: ConvexCall[];
-  signInCalls: ConvexCall[];
-  validateSessionCalls: ConvexCall[];
-  getCurrentUser: () => AuthUser;
-};
-
-const baseUser: AuthUser = {
-  id: "user_1",
-  email: "test.user@example.com",
-  name: "Test User",
-  role: "owner",
-  companyId: "company_1",
-  status: "active",
-};
-
-const convexSuccessResponse = (value: unknown) => ({
-  status: 200,
-  contentType: "application/json",
-  body: JSON.stringify({
-    status: "success",
-    value,
-    logLines: [],
-  }),
-});
-
-const decodeConvexRequest = (route: Route) => {
-  const bodyText = route.request().postData() ?? "{}";
-  const body = JSON.parse(bodyText) as {
-    path?: string;
-    args?: unknown[];
-  };
-  const [encodedArgs] = body.args ?? [];
-  const decodedArgs = encodedArgs
-    ? (jsonToConvex(encodedArgs as unknown) as Record<string, unknown>)
-    : {};
-  return { path: body.path, args: decodedArgs };
-};
-
-const setupConvexMocks = async (
-  page: Page,
-  options: { user?: Partial<AuthUser> } = {},
-): Promise<ConvexMocks> => {
-  const signUpCalls: ConvexCall[] = [];
-  const signInCalls: ConvexCall[] = [];
-  const validateSessionCalls: ConvexCall[] = [];
-
-  let activeToken: string | null = null;
-  let currentUser: AuthUser = { ...baseUser, ...options.user };
-
-  const respond = (route: Route, value: unknown) =>
-    route.fulfill(convexSuccessResponse(value));
-
-  await page.route("**/api/query_ts", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ ts: Date.now().toString() }),
-    }),
-  );
-
-  const handleQuery = (route: Route) => {
-    const { path } = decodeConvexRequest(route);
-    if (path?.startsWith("admin:")) {
-      return respond(route, { data: [], total: 0 });
-    }
-    return respond(route, null);
-  };
-
-  await page.route("**/api/query", handleQuery);
-  await page.route("**/api/query_at_ts", handleQuery);
-
-  await page.route("**/api/mutation", (route) => respond(route, {}));
-
-  await page.route("**/api/action", (route) => {
-    const { path, args } = decodeConvexRequest(route);
-
-    if (path === "auth:signUp") {
-      signUpCalls.push(args);
-      currentUser = {
-        ...currentUser,
-        id: "user_signup",
-        email: args.email,
-        name: args.name ?? currentUser.name,
-        role: "owner",
-      };
-      activeToken = "test-signup-token";
-      return respond(route, { token: activeToken, user: currentUser });
-    }
-
-    if (path === "auth:signIn") {
-      signInCalls.push(args);
-      currentUser = {
-        ...currentUser,
-        email: args.email,
-      };
-      activeToken = "test-session-token";
-      return respond(route, { token: activeToken, user: currentUser });
-    }
-
-    if (path === "auth:validateSession") {
-      validateSessionCalls.push(args);
-      if (!activeToken) {
-        return respond(route, null);
-      }
-      const now = new Date();
-      return respond(route, {
-        session: {
-          token: activeToken,
-          userId: currentUser.id,
-          createdAt: now.toISOString(),
-          updatedAt: now.toISOString(),
-          expiresAt: new Date(
-            now.getTime() + 24 * 60 * 60 * 1000,
-          ).toISOString(),
-        },
-        user: currentUser,
-      });
-    }
-
-    return respond(route, {});
-  });
-
-  return {
-    signUpCalls,
-    signInCalls,
-    validateSessionCalls,
-    getCurrentUser: () => currentUser,
-  };
-};
+import { setupConvexMocks } from "./utils/convexMocks";
 
 test.describe("Authentication flows", () => {
   test("allows a new owner to sign up and sign in", async ({ page }) => {
@@ -167,7 +25,7 @@ test.describe("Authentication flows", () => {
     await page.getByRole("button", { name: "Create account" }).click();
 
     await expect(
-      page.getByRole("heading", { level: 2, name: /companies/i }),
+      page.getByRole("heading", { level: 1, name: /dashboard/i }),
     ).toBeVisible();
 
     await expect
@@ -208,7 +66,7 @@ test.describe("Authentication flows", () => {
     await page.getByRole("button", { name: "Sign in" }).click();
 
     await expect(
-      page.getByRole("heading", { level: 2, name: /companies/i }),
+      page.getByRole("heading", { level: 1, name: /dashboard/i }),
     ).toBeVisible();
 
     await expect

--- a/tests/e2e/companies-edit.spec.ts
+++ b/tests/e2e/companies-edit.spec.ts
@@ -1,0 +1,281 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { jsonToConvex } from "convex/values";
+import { TOKEN_STORAGE_KEY, USER_STORAGE_KEY } from "../../src/lib/authStorage";
+
+type ConvexArgs = Record<string, unknown>;
+
+type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+};
+
+type CompanyRecord = {
+  name: string;
+  plan: string;
+  timezone: string;
+  branding: {
+    logoUrl: string;
+    greetingName: string;
+  };
+  createdAt: number;
+};
+
+const convexSuccessResponse = (value: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    status: "success",
+    value,
+    logLines: [],
+  }),
+});
+
+const decodeConvexRequest = (route: Route) => {
+  const bodyText = route.request().postData() ?? "{}";
+  const body = JSON.parse(bodyText) as {
+    path?: string;
+    args?: unknown[];
+  };
+  const [encodedArgs] = body.args ?? [];
+  const decodedArgs = encodedArgs
+    ? (jsonToConvex(encodedArgs as unknown) as Record<string, unknown>)
+    : {};
+  return { path: body.path, args: decodedArgs };
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const mergeDeep = (
+  target: Record<string, unknown>,
+  updates?: Record<string, unknown>,
+) => {
+  if (!updates) {
+    return target;
+  }
+
+  const next: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(updates)) {
+    if (isPlainObject(value)) {
+      const existing = next[key];
+      next[key] = mergeDeep(
+        isPlainObject(existing) ? (existing as Record<string, unknown>) : {},
+        value,
+      );
+    } else {
+      next[key] = value;
+    }
+  }
+  return next;
+};
+
+const clone = <T>(value: T): T =>
+  value === undefined
+    ? value
+    : (JSON.parse(JSON.stringify(value)) as unknown as T);
+
+const setupCompanyEditTest = async (
+  page: Page,
+  options: {
+    companyId: string;
+    company: CompanyRecord;
+    user?: AuthUser;
+  },
+) => {
+  const {
+    companyId,
+    company,
+    user = {
+      id: "user_owner",
+      email: "owner@example.com",
+      name: "Owner",
+      role: "owner",
+    },
+  } = options;
+
+  let currentCompany: Record<string, unknown> = clone(company);
+  const updateCalls: ConvexArgs[] = [];
+  const validateSessionCalls: ConvexArgs[] = [];
+
+  await page.addInitScript(
+    ({ tokenKey, tokenValue, storedUserKey, storedUser }) => {
+      window.localStorage.setItem(tokenKey, tokenValue);
+      window.localStorage.setItem(storedUserKey, JSON.stringify(storedUser));
+    },
+    {
+      tokenKey: TOKEN_STORAGE_KEY,
+      tokenValue: "test-session-token",
+      storedUserKey: USER_STORAGE_KEY,
+      storedUser: user,
+    },
+  );
+
+  const respond = (route: Route, value: unknown) =>
+    route.fulfill(convexSuccessResponse(value));
+
+  await page.route("**/api/query_ts", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ts: Date.now().toString() }),
+    }),
+  );
+
+  const getCompanyDocument = () => ({
+    _id: companyId,
+    ...currentCompany,
+  });
+
+  const handleQuery = (route: Route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === "admin:get") {
+      if ((args?.id as string | undefined) === companyId) {
+        return respond(route, getCompanyDocument());
+      }
+      return respond(route, null);
+    }
+
+    if (path === "admin:list") {
+      return respond(route, {
+        data: [getCompanyDocument()],
+        total: 1,
+      });
+    }
+
+    return respond(route, null);
+  };
+
+  await page.route("**/api/query", handleQuery);
+  await page.route("**/api/query_at_ts", handleQuery);
+
+  await page.route("**/api/mutation", (route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === "admin:update") {
+      updateCalls.push(clone(args));
+      const updates = args.data as Record<string, unknown> | undefined;
+      currentCompany = mergeDeep(
+        currentCompany,
+        updates ? clone(updates) : undefined,
+      );
+      return respond(route, getCompanyDocument());
+    }
+
+    return respond(route, {});
+  });
+
+  await page.route("**/api/action", (route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === "auth:validateSession") {
+      validateSessionCalls.push(clone(args));
+      const now = new Date().toISOString();
+      return respond(route, {
+        session: {
+          token: "test-session-token",
+          userId: user.id,
+          createdAt: now,
+          updatedAt: now,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        },
+        user,
+      });
+    }
+
+    return respond(route, {});
+  });
+
+  return {
+    getCurrentCompany: () => clone(currentCompany),
+    updateCalls,
+    validateSessionCalls,
+  };
+};
+
+test.describe("Company editing", () => {
+  test("persists only modified fields when updating a company", async ({
+    page,
+  }) => {
+    const companyId = "company_123";
+    const initialCompany: CompanyRecord = {
+      name: "Alpha Logistics",
+      plan: "starter",
+      timezone: "America/New_York",
+      branding: {
+        logoUrl: "https://example.com/logo.svg",
+        greetingName: "Alpha team",
+      },
+      createdAt: 1_700_000_000_000,
+    };
+
+    const mocks = await setupCompanyEditTest(page, {
+      companyId,
+      company: initialCompany,
+    });
+
+    await page.goto(`/companies/${companyId}`);
+
+    const nameField = page.getByLabel(/^Name\b/);
+    await expect(nameField).toHaveValue(initialCompany.name);
+
+    const timezoneField = page.getByLabel("Timezone");
+    await expect(timezoneField).toHaveValue(initialCompany.timezone);
+
+    const planTrigger = page.getByRole("combobox").first();
+    await expect(planTrigger).toHaveText("Starter");
+
+    await expect(page.getByLabel("Branding · Greeting Name")).toHaveValue(
+      initialCompany.branding.greetingName,
+    );
+
+    await nameField.fill("Alpha Logistics International");
+    await timezoneField.fill("America/Los_Angeles");
+
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Element updated")).toBeVisible();
+
+    await expect.poll(() => mocks.updateCalls.length).toBe(1);
+
+    const [updateCall] = mocks.updateCalls;
+    expect(updateCall).toMatchObject({
+      table: "companies",
+      id: companyId,
+    });
+
+    const updatedData = (updateCall.data ?? {}) as Record<string, unknown>;
+    expect(updatedData).toMatchObject({
+      name: "Alpha Logistics International",
+      timezone: "America/Los_Angeles",
+      branding: initialCompany.branding,
+      plan: initialCompany.plan,
+      createdAt: initialCompany.createdAt,
+    });
+    expect(Object.keys(updatedData).sort()).toEqual([
+      "branding",
+      "createdAt",
+      "name",
+      "plan",
+      "timezone",
+    ]);
+
+    await expect(page).toHaveURL(`/companies`);
+
+    await page.goto(`/companies/${companyId}/show`);
+
+    const main = page.getByRole("main");
+    await expect(
+      main.getByRole("heading", {
+        level: 2,
+        name: "Company Alpha Logistics International",
+      }),
+    ).toBeVisible();
+    await expect(
+      main.getByText("America/Los_Angeles", { exact: true }),
+    ).toBeVisible();
+    await expect(main.getByText("starter", { exact: true })).toBeVisible();
+  });
+});

--- a/tests/e2e/dashboard-charts.spec.ts
+++ b/tests/e2e/dashboard-charts.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { setupConvexMocks } from "./utils/convexMocks";
+
+type CallsOverTimePoint = {
+  date: string;
+  count: number;
+};
+
+type EscalationsByPriorityPoint = {
+  priority: string;
+  value: number;
+};
+
+type DashboardResponse = {
+  metrics: {
+    callsHandled: number;
+    aiResolutionRate: number;
+    openEscalations: number;
+    unitsUnderManagement: number;
+  };
+  charts: {
+    callsOverTime: CallsOverTimePoint[];
+    escalationsByPriority: EscalationsByPriorityPoint[];
+  };
+  lastUpdated: number | null;
+};
+
+const completeLogin = async (page: Page) => {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("test.user@example.com");
+  await page.getByLabel("Password").fill("password!23");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+};
+
+const renderDashboard = async (page: Page, data: DashboardResponse) => {
+  await setupConvexMocks(page, {
+    queryHandlers: {
+      "admin:dashboard": async () => data,
+    },
+  });
+
+  await completeLogin(page);
+};
+
+test.describe("Dashboard charts", () => {
+  test("renders charts with populated data", async ({ page }) => {
+    await renderDashboard(page, {
+      metrics: {
+        callsHandled: 128,
+        aiResolutionRate: 0.62,
+        openEscalations: 7,
+        unitsUnderManagement: 342,
+      },
+      charts: {
+        callsOverTime: [
+          { date: "2024-03-01", count: 12 },
+          { date: "2024-03-02", count: 18 },
+          { date: "2024-03-03", count: 27 },
+        ],
+        escalationsByPriority: [
+          { priority: "Critical", value: 2 },
+          { priority: "High", value: 3 },
+          { priority: "Medium", value: 2 },
+        ],
+      },
+      lastUpdated: Date.UTC(2024, 2, 4),
+    });
+
+    await expect(
+      page.getByRole("group", { name: "Calls over time chart" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('[data-testid="calls-over-time-chart"]')
+        .getByRole("application"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("group", { name: "Escalations by priority chart" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('[data-testid="escalations-by-priority-chart"]')
+        .getByRole("application"),
+    ).toBeVisible();
+    await expect(page.getByText("Critical")).toBeVisible();
+    await expect(page.getByText("High")).toBeVisible();
+  });
+
+  test("falls back to empty states when no activity exists", async ({
+    page,
+  }) => {
+    await renderDashboard(page, {
+      metrics: {
+        callsHandled: 0,
+        aiResolutionRate: 0,
+        openEscalations: 0,
+        unitsUnderManagement: 0,
+      },
+      charts: {
+        callsOverTime: [
+          { date: "2024-03-01", count: 0 },
+          { date: "2024-03-02", count: 0 },
+          { date: "2024-03-03", count: 0 },
+        ],
+        escalationsByPriority: [],
+      },
+      lastUpdated: null,
+    });
+
+    await expect(
+      page.getByText("No call activity recorded in this window yet."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("New calls will appear here in real time."),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('[data-testid="calls-over-time-chart"]')
+        .getByRole("application"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText("No open escalations at the moment."),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('[data-testid="escalations-by-priority-chart"]')
+        .getByRole("application"),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/dashboard-kpis.spec.ts
+++ b/tests/e2e/dashboard-kpis.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { TOKEN_STORAGE_KEY, USER_STORAGE_KEY } from "../../src/lib/authStorage";
+
+import { setupConvexMocks } from "./utils/convexMocks";
+
+const createDeferred = <T = void>() => {
+  type Resolve = (value: T | PromiseLike<T>) => void;
+  type Reject = (reason?: unknown) => void;
+
+  let resolve: Resolve | undefined;
+  let reject: Reject | undefined;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  if (!resolve || !reject) {
+    throw new Error("Failed to create deferred promise");
+  }
+
+  return { promise, resolve, reject };
+};
+
+const loginExistingUser = async (page: Page) => {
+  await page.goto("/login");
+
+  await page.getByLabel("Email").fill("OWNER@example.com  ");
+  await page.getByLabel("Password").fill("owner-password!");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => window.localStorage.getItem(key),
+        TOKEN_STORAGE_KEY,
+      ),
+    )
+    .toBe("test-session-token");
+
+  const storedUserRaw = await page.evaluate((key) => {
+    return window.localStorage.getItem(key);
+  }, USER_STORAGE_KEY);
+
+  const storedUser = storedUserRaw ? JSON.parse(storedUserRaw) : null;
+  expect(storedUser?.companyId).toBeTruthy();
+};
+
+test.describe("Dashboard KPIs", () => {
+  test("renders KPI metrics from Convex data", async ({ page }) => {
+    const metrics = {
+      callsHandled: 3271,
+      aiResolutionRate: 0.642,
+      openEscalations: 12,
+      unitsUnderManagement: 843,
+    };
+
+    const dashboardResponse = {
+      metrics,
+      charts: {
+        callsOverTime: [
+          { date: "2024-05-06", count: 124 },
+          { date: "2024-05-07", count: 156 },
+          { date: "2024-05-08", count: 201 },
+          { date: "2024-05-09", count: 189 },
+          { date: "2024-05-10", count: 175 },
+          { date: "2024-05-11", count: 167 },
+          { date: "2024-05-12", count: 142 },
+        ],
+        escalationsByPriority: [
+          { priority: "Critical", value: 3 },
+          { priority: "High", value: 5 },
+          { priority: "Medium", value: 2 },
+          { priority: "Low", value: 1 },
+        ],
+      },
+      lastUpdated: Date.UTC(2024, 4, 12, 15, 30, 0),
+    };
+
+    const metricsResponse = createDeferred<typeof dashboardResponse>();
+
+    let dashboardCallCount = 0;
+
+    await setupConvexMocks(page, {
+      queryHandlers: {
+        "admin:dashboard": async () => {
+          dashboardCallCount += 1;
+          return metricsResponse.promise;
+        },
+      },
+    });
+
+    await loginExistingUser(page);
+
+    await page.goto("/");
+
+    await expect.poll(() => dashboardCallCount).toBeGreaterThan(0);
+
+    await expect(page.locator('[data-slot="skeleton"]').first()).toBeVisible();
+
+    metricsResponse.resolve(dashboardResponse);
+
+    const numberFormatter = new Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 0,
+    });
+    const percentFormatter = new Intl.NumberFormat(undefined, {
+      style: "percent",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+
+    const expectedMetrics = {
+      "Calls handled": numberFormatter.format(metrics.callsHandled),
+      "AI resolution": percentFormatter.format(metrics.aiResolutionRate),
+      "Open escalations": numberFormatter.format(metrics.openEscalations),
+      "Units under management": numberFormatter.format(
+        metrics.unitsUnderManagement,
+      ),
+    } as const;
+
+    await expect(page.locator('[data-slot="skeleton"]')).toHaveCount(0);
+
+    for (const [label, value] of Object.entries(expectedMetrics)) {
+      const card = page.locator('div[data-slot="card"]').filter({
+        has: page.locator('div[data-slot="card-title"]', { hasText: label }),
+      });
+      await expect(card).toHaveCount(1);
+      await expect(card.locator('div[data-slot="card-title"]')).toHaveText(
+        label,
+      );
+      await expect(card.getByText(value, { exact: true })).toBeVisible();
+    }
+
+    const expectedLastUpdated = dateFormatter.format(
+      new Date(dashboardResponse.lastUpdated),
+    );
+    await expect(
+      page.getByText(new RegExp(`Last updated\\s+${expectedLastUpdated}`)),
+    ).toBeVisible();
+  });
+
+  test("shows outage fallback messaging when dashboard data is unavailable", async ({
+    page,
+  }) => {
+    const outageResponse = createDeferred<null>();
+
+    let outageCallCount = 0;
+
+    await setupConvexMocks(page, {
+      queryHandlers: {
+        "admin:dashboard": async () => {
+          outageCallCount += 1;
+          return outageResponse.promise;
+        },
+      },
+    });
+
+    await loginExistingUser(page);
+
+    await page.goto("/");
+
+    await expect.poll(() => outageCallCount).toBeGreaterThan(0);
+
+    await expect(page.locator('[data-slot="alert-title"]').first()).toHaveText(
+      "Live data is temporarily unavailable",
+      { timeout: 15000 },
+    );
+
+    await expect(
+      page.locator('[data-slot="alert-description"]').first(),
+    ).toContainText("We couldn't reach Convex to refresh metrics.", {
+      timeout: 15000,
+    });
+
+    const fallbackMetrics = {
+      "Calls handled": "0",
+      "AI resolution": "0%",
+      "Open escalations": "0",
+      "Units under management": "0",
+    } as const;
+
+    for (const [label, value] of Object.entries(fallbackMetrics)) {
+      const card = page.locator('div[data-slot="card"]').filter({
+        has: page.locator('div[data-slot="card-title"]', { hasText: label }),
+      });
+      await expect(card).toHaveCount(1);
+      await expect(card.getByText(value, { exact: true })).toBeVisible();
+    }
+
+    outageResponse.resolve(null);
+  });
+});

--- a/tests/e2e/properties-list.spec.ts
+++ b/tests/e2e/properties-list.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { jsonToConvex } from "convex/values";
+
+import { TOKEN_STORAGE_KEY, USER_STORAGE_KEY } from "../../src/lib/authStorage";
+
+type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+  status: string;
+};
+
+type ConvexRequest = {
+  path?: string;
+  args?: Record<string, unknown>;
+};
+
+type PropertyDoc = {
+  _id: string;
+  name: string;
+  companyId: string;
+  timeZone: string;
+  updatedAt: string;
+};
+
+type CompanyDoc = {
+  _id: string;
+  name: string;
+};
+
+const baseUser: AuthUser = {
+  id: "user_1",
+  email: "owner@example.com",
+  name: "Test Owner",
+  role: "owner",
+  companyId: "company_1",
+  status: "active",
+};
+
+const convexSuccessResponse = (value: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    status: "success",
+    value,
+    logLines: [],
+  }),
+});
+
+const decodeConvexRequest = (route: Route): ConvexRequest => {
+  const bodyText = route.request().postData() ?? "{}";
+  const body = JSON.parse(bodyText) as {
+    path?: string;
+    args?: unknown[];
+  };
+  const [encodedArgs] = body.args ?? [];
+  const decodedArgs = encodedArgs
+    ? (jsonToConvex(encodedArgs as unknown) as Record<string, unknown>)
+    : {};
+  return { path: body.path, args: decodedArgs };
+};
+
+const setupAuthenticatedApp = async (
+  page: Page,
+  {
+    user: userOverrides,
+    properties,
+    companies,
+  }: {
+    user?: Partial<AuthUser>;
+    properties: PropertyDoc[];
+    companies: CompanyDoc[];
+  },
+) => {
+  const user: AuthUser = { ...baseUser, ...userOverrides };
+  const token = "test-session-token";
+  const companiesById = new Map(
+    companies.map((company) => [company._id, company]),
+  );
+
+  await page.addInitScript(
+    ({ tokenKey, userKey, tokenValue, storedUser }) => {
+      window.localStorage.setItem(tokenKey, tokenValue);
+      window.localStorage.setItem(userKey, JSON.stringify(storedUser));
+    },
+    {
+      tokenKey: TOKEN_STORAGE_KEY,
+      userKey: USER_STORAGE_KEY,
+      tokenValue: token,
+      storedUser: user,
+    },
+  );
+
+  const respond = (route: Route, value: unknown) =>
+    route.fulfill(convexSuccessResponse(value));
+
+  await page.route("**/api/query_ts", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ts: Date.now().toString() }),
+    }),
+  );
+
+  const handleQuery = (route: Route) => {
+    const { path, args } = decodeConvexRequest(route);
+    const table = typeof args?.table === "string" ? args.table : undefined;
+
+    if (path === "admin:list") {
+      if (table === "properties") {
+        return respond(route, { data: properties, total: properties.length });
+      }
+      if (table === "companies") {
+        const data = Array.from(companiesById.values());
+        return respond(route, { data, total: data.length });
+      }
+      return respond(route, { data: [], total: 0 });
+    }
+
+    if (path === "admin:getMany" && table === "companies") {
+      const ids = Array.isArray(args?.ids) ? (args.ids as string[]) : [];
+      const docs = ids
+        .map((id) => companiesById.get(id))
+        .filter((doc): doc is CompanyDoc => !!doc);
+      return respond(route, docs);
+    }
+
+    if (path === "admin:get" && table === "companies") {
+      const id = typeof args?.id === "string" ? args.id : undefined;
+      return respond(route, id ? (companiesById.get(id) ?? null) : null);
+    }
+
+    if (path?.startsWith("admin:")) {
+      return respond(route, { data: [], total: 0 });
+    }
+
+    return respond(route, null);
+  };
+
+  await page.route("**/api/query", handleQuery);
+  await page.route("**/api/query_at_ts", handleQuery);
+
+  await page.route("**/api/mutation", (route) => respond(route, {}));
+
+  await page.route("**/api/action", (route) => {
+    const { path } = decodeConvexRequest(route);
+    if (path === "auth:validateSession") {
+      const now = new Date();
+      return respond(route, {
+        session: {
+          token,
+          userId: user.id,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          expiresAt: new Date(
+            now.getTime() + 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        },
+        user,
+      });
+    }
+
+    if (path === "auth:signOut") {
+      return respond(route, null);
+    }
+
+    return respond(route, null);
+  });
+};
+
+const formatUpdatedAt = (page: Page, value: string) =>
+  page.evaluate((timestamp) => new Date(timestamp).toLocaleString(), value);
+
+test.describe("Properties list", () => {
+  test("displays properties with their companies and metadata", async ({
+    page,
+  }) => {
+    const propertyDocs: PropertyDoc[] = [
+      {
+        _id: "property_1",
+        name: "Sunset Villa",
+        companyId: "company_1",
+        timeZone: "America/Los_Angeles",
+        updatedAt: "2024-03-01T12:00:00.000Z",
+      },
+      {
+        _id: "property_2",
+        name: "Mountain Retreat",
+        companyId: "company_2",
+        timeZone: "America/Denver",
+        updatedAt: "2024-04-15T18:30:00.000Z",
+      },
+    ];
+
+    const companyDocs: CompanyDoc[] = [
+      { _id: "company_1", name: "Acme Hospitality" },
+      { _id: "company_2", name: "Summit Holdings" },
+    ];
+
+    await setupAuthenticatedApp(page, {
+      properties: propertyDocs,
+      companies: companyDocs,
+    });
+
+    await page.goto("/properties");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: /properties/i }),
+    ).toBeVisible();
+
+    const table = page.getByRole("table");
+    const headerRow = table
+      .getByRole("rowgroup")
+      .first()
+      .getByRole("row")
+      .first();
+    await expect(headerRow.getByRole("cell", { name: /name/i })).toBeVisible();
+    await expect(
+      headerRow.getByRole("cell", { name: /company/i }),
+    ).toBeVisible();
+    await expect(
+      headerRow.getByRole("cell", { name: /time zone/i }),
+    ).toBeVisible();
+    await expect(
+      headerRow.getByRole("cell", { name: /updated/i }),
+    ).toBeVisible();
+
+    const rows = table.locator("tbody tr");
+    await expect(rows).toHaveCount(propertyDocs.length);
+
+    const actualRows = new Map<
+      string,
+      { company: string; timeZone: string; updated: string }
+    >();
+    const rowCount = await rows.count();
+    for (let index = 0; index < rowCount; index += 1) {
+      const cells = rows.nth(index).locator("td");
+      const name = (await cells.nth(1).innerText()).trim();
+      actualRows.set(name, {
+        company: (await cells.nth(2).innerText()).trim(),
+        timeZone: (await cells.nth(3).innerText()).trim(),
+        updated: (await cells.nth(4).innerText()).trim(),
+      });
+    }
+
+    for (const property of propertyDocs) {
+      const company = companyDocs.find((doc) => doc._id === property.companyId);
+      const row = actualRows.get(property.name);
+      expect(row).toBeDefined();
+      expect(row?.company).toBe(company?.name ?? "");
+      expect(row?.timeZone).toBe(property.timeZone);
+      const expectedUpdated = await formatUpdatedAt(page, property.updatedAt);
+      expect(row?.updated).toBe(expectedUpdated);
+    }
+  });
+
+  test("shows the empty state when no properties are returned", async ({
+    page,
+  }) => {
+    await setupAuthenticatedApp(page, {
+      properties: [],
+      companies: [],
+    });
+
+    await page.goto("/properties");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: /properties/i }),
+    ).toBeVisible();
+
+    await expect(page.getByText("No results found.")).toBeVisible();
+  });
+});

--- a/tests/e2e/utils/convexMocks.ts
+++ b/tests/e2e/utils/convexMocks.ts
@@ -1,0 +1,477 @@
+import { type Page, type Route } from "@playwright/test";
+import { convexToJson, jsonToConvex } from "convex/values";
+
+type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+  status: string;
+};
+
+type ConvexCall = Record<string, unknown>;
+
+type ConvexMocks = {
+  signUpCalls: ConvexCall[];
+  signInCalls: ConvexCall[];
+  validateSessionCalls: ConvexCall[];
+  getCurrentUser: () => AuthUser;
+};
+
+type QueryHandler = (
+  args: Record<string, unknown>,
+) => unknown | Promise<unknown>;
+
+type ExposedQueryPayload = {
+  path: string;
+  args: unknown[];
+};
+
+declare global {
+  interface Window {
+    __convexHandleQuery: (
+      payload: ExposedQueryPayload,
+    ) => Promise<{ value: unknown }>;
+  }
+}
+
+type SetupConvexMocksOptions = {
+  user?: Partial<AuthUser>;
+  queryHandlers?: Record<string, QueryHandler>;
+};
+
+const baseUser: AuthUser = {
+  id: "user_1",
+  email: "test.user@example.com",
+  name: "Test User",
+  role: "owner",
+  companyId: "company_1",
+  status: "active",
+};
+
+const convexSuccessResponse = (value: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    status: "success",
+    value,
+    logLines: [],
+  }),
+});
+
+const decodeConvexRequest = (route: Route) => {
+  const bodyText = route.request().postData() ?? "{}";
+  const body = JSON.parse(bodyText) as {
+    path?: string;
+    args?: unknown[];
+  };
+  const [encodedArgs] = body.args ?? [];
+  const decodedArgs = encodedArgs
+    ? (jsonToConvex(encodedArgs as unknown) as Record<string, unknown>)
+    : {};
+  return { path: body.path, args: decodedArgs };
+};
+
+export const setupConvexMocks = async (
+  page: Page,
+  options: SetupConvexMocksOptions = {},
+): Promise<ConvexMocks> => {
+  const signUpCalls: ConvexCall[] = [];
+  const signInCalls: ConvexCall[] = [];
+  const validateSessionCalls: ConvexCall[] = [];
+
+  let activeToken: string | null = null;
+  let currentUser: AuthUser = { ...baseUser, ...options.user };
+
+  const respond = (route: Route, value: unknown) =>
+    route.fulfill(convexSuccessResponse(convexToJson(value)));
+
+  await page.route("**/api/query_ts", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ts: Date.now().toString() }),
+    }),
+  );
+
+  await page.exposeFunction(
+    "__convexHandleQuery",
+    async ({ path, args }: ExposedQueryPayload) => {
+      const handler = options.queryHandlers?.[path];
+      if (!handler) {
+        return { value: null };
+      }
+
+      const decodedArgs = (args ?? []).map((arg) =>
+        jsonToConvex(arg as unknown),
+      );
+      const firstArg =
+        decodedArgs.length > 0
+          ? (decodedArgs[0] as Record<string, unknown>)
+          : {};
+      const result = await handler(firstArg);
+      return { value: convexToJson(result) };
+    },
+  );
+
+  await page.addInitScript(() => {
+    const encodeU64 = (value: number) => {
+      const buffer = new ArrayBuffer(8);
+      const view = new DataView(buffer);
+      view.setBigUint64(0, BigInt(value), true);
+      let binary = "";
+      const bytes = new Uint8Array(buffer);
+      for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+      }
+      return btoa(binary);
+    };
+
+    const OriginalWebSocket = window.WebSocket;
+
+    type ConvexMessage = {
+      type: string;
+      baseVersion?: number;
+      newVersion?: number;
+      modifications?: Array<
+        | { type: "Add"; queryId: number; udfPath: string; args: unknown[] }
+        | { type: "Remove"; queryId: number }
+      >;
+      tokenType?: string;
+      baseIdentityVersion?: number;
+    };
+
+    class ConvexMockWebSocket {
+      static readonly CONNECTING = OriginalWebSocket.CONNECTING;
+      static readonly OPEN = OriginalWebSocket.OPEN;
+      static readonly CLOSING = OriginalWebSocket.CLOSING;
+      static readonly CLOSED = OriginalWebSocket.CLOSED;
+
+      readonly url: string = "";
+      readonly protocol: string = "";
+      readonly extensions = "";
+      readonly bufferedAmount = 0;
+      binaryType: BinaryType = "blob";
+      readyState = OriginalWebSocket.CONNECTING;
+
+      onopen: ((event: Event) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent<string>) => void) | null = null;
+
+      private readonly listeners = new Map<
+        string,
+        Set<(event: Event) => void>
+      >();
+      private querySetVersion = 0;
+      private identityVersion = 0;
+      private timestamp = 0;
+      private readonly isConvexSocket: boolean;
+      private closed = false;
+
+      constructor(url: string | URL, protocols?: string | string[]) {
+        const urlString = typeof url === "string" ? url : url.toString();
+        this.isConvexSocket = urlString.includes("/api");
+
+        if (!this.isConvexSocket) {
+          // Delegate to the original WebSocket implementation for non-Convex URLs.
+          return new OriginalWebSocket(
+            url,
+            protocols,
+          ) as unknown as ConvexMockWebSocket;
+        }
+
+        this.url = urlString;
+        if (Array.isArray(protocols)) {
+          this.protocol = protocols[0] ?? "";
+        } else {
+          this.protocol = protocols ?? "";
+        }
+
+        queueMicrotask(() => {
+          if (this.closed) {
+            return;
+          }
+          this.readyState = OriginalWebSocket.OPEN;
+          const event = new Event("open");
+          this.dispatchEvent(event);
+        });
+      }
+
+      addEventListener(type: string, listener: (event: Event) => void) {
+        if (!this.listeners.has(type)) {
+          this.listeners.set(type, new Set());
+        }
+        this.listeners.get(type)!.add(listener);
+      }
+
+      removeEventListener(type: string, listener: (event: Event) => void) {
+        this.listeners.get(type)?.delete(listener);
+      }
+
+      dispatchEvent(event: Event) {
+        const listeners = this.listeners.get(event.type);
+        if (listeners) {
+          for (const listener of listeners) {
+            listener(event);
+          }
+        }
+
+        switch (event.type) {
+          case "open": {
+            this.onopen?.(event);
+            break;
+          }
+          case "message": {
+            this.onmessage?.(event as MessageEvent<string>);
+            break;
+          }
+          case "close": {
+            this.onclose?.(event as CloseEvent);
+            break;
+          }
+          case "error": {
+            this.onerror?.(event);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+
+      private async handleModifyQuerySet(message: ConvexMessage) {
+        const modifications = message.modifications ?? [];
+
+        const resolvedModifications = await Promise.all(
+          modifications.map(async (modification) => {
+            if (modification.type === "Add") {
+              try {
+                const response = await window.__convexHandleQuery({
+                  path: modification.udfPath,
+                  args: modification.args,
+                });
+                return {
+                  type: "QueryUpdated" as const,
+                  queryId: modification.queryId,
+                  value: response.value,
+                  logLines: [] as string[],
+                  journal: null,
+                };
+              } catch (error) {
+                const errorMessage =
+                  error instanceof Error ? error.message : String(error);
+                return {
+                  type: "QueryFailed" as const,
+                  queryId: modification.queryId,
+                  errorMessage,
+                  logLines: [] as string[],
+                  errorData: null,
+                  journal: null,
+                };
+              }
+            }
+
+            return {
+              type: "QueryRemoved" as const,
+              queryId: modification.queryId,
+            };
+          }),
+        );
+
+        if (typeof message.baseVersion === "number") {
+          this.querySetVersion = message.baseVersion;
+        }
+
+        const startVersion = {
+          querySet: this.querySetVersion,
+          ts: encodeU64(this.timestamp),
+          identity: this.identityVersion,
+        };
+
+        const endQuerySet =
+          message.newVersion ??
+          (typeof message.baseVersion === "number"
+            ? message.baseVersion + 1
+            : this.querySetVersion + 1);
+
+        this.querySetVersion = endQuerySet;
+        this.timestamp += 1;
+
+        const endVersion = {
+          querySet: endQuerySet,
+          ts: encodeU64(this.timestamp),
+          identity: this.identityVersion,
+        };
+
+        const transition = {
+          type: "Transition",
+          startVersion,
+          endVersion,
+          modifications: resolvedModifications,
+          clientClockSkew: 0,
+          serverTs: Date.now(),
+        };
+
+        const event = new MessageEvent("message", {
+          data: JSON.stringify(transition),
+        });
+
+        this.dispatchEvent(event);
+      }
+
+      private handleAuthenticate(message: ConvexMessage) {
+        if (typeof message.baseVersion === "number") {
+          this.identityVersion = message.baseVersion;
+        }
+      }
+
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        if (!this.isConvexSocket || typeof data !== "string") {
+          return;
+        }
+
+        const message = JSON.parse(data) as ConvexMessage;
+
+        if (message.type === "ModifyQuerySet") {
+          this.handleModifyQuerySet(message).catch((error) => {
+            console.error("Convex mock WebSocket error", error);
+            const event = new Event("error");
+            this.dispatchEvent(event);
+          });
+          return;
+        }
+
+        if (message.type === "Authenticate") {
+          this.handleAuthenticate(message);
+          return;
+        }
+      }
+
+      close(code?: number, reason?: string) {
+        if (this.closed) {
+          return;
+        }
+        this.readyState = OriginalWebSocket.CLOSED;
+        this.closed = true;
+        const event = new CloseEvent("close", { code, reason: reason ?? "" });
+        this.dispatchEvent(event);
+      }
+
+      get CONNECTING() {
+        return OriginalWebSocket.CONNECTING;
+      }
+
+      get OPEN() {
+        return OriginalWebSocket.OPEN;
+      }
+
+      get CLOSING() {
+        return OriginalWebSocket.CLOSING;
+      }
+
+      get CLOSED() {
+        return OriginalWebSocket.CLOSED;
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      writable: true,
+      value: ConvexMockWebSocket as unknown as typeof WebSocket,
+    });
+  });
+
+  const handleQuery = async (route: Route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path) {
+      const handler = options.queryHandlers?.[path];
+      if (handler) {
+        const value = await handler(args ?? {});
+        await respond(route, value);
+        return;
+      }
+    }
+
+    if (path?.startsWith("admin:")) {
+      await respond(route, { data: [], total: 0 });
+      return;
+    }
+
+    await respond(route, null);
+  };
+
+  await page.route("**/api/query", handleQuery);
+  await page.route("**/api/query_at_ts", handleQuery);
+
+  await page.route("**/api/mutation", (route) => respond(route, {}));
+
+  await page.route("**/api/action", async (route) => {
+    const { path, args } = decodeConvexRequest(route);
+
+    if (path === "auth:signUp") {
+      signUpCalls.push(args);
+      currentUser = {
+        ...currentUser,
+        id: "user_signup",
+        email: (args.email as string | undefined) ?? currentUser.email,
+        name: (args.name as string | undefined) ?? currentUser.name,
+        role: "owner",
+      };
+      activeToken = "test-signup-token";
+      await respond(route, { token: activeToken, user: currentUser });
+      return;
+    }
+
+    if (path === "auth:signIn") {
+      signInCalls.push(args);
+      currentUser = {
+        ...currentUser,
+        email: (args.email as string | undefined) ?? currentUser.email,
+      };
+      activeToken = "test-session-token";
+      await respond(route, { token: activeToken, user: currentUser });
+      return;
+    }
+
+    if (path === "auth:validateSession") {
+      validateSessionCalls.push(args);
+      if (!activeToken) {
+        await respond(route, null);
+        return;
+      }
+      const now = new Date();
+      await respond(route, {
+        session: {
+          token: activeToken,
+          userId: currentUser.id,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          expiresAt: new Date(
+            now.getTime() + 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        },
+        user: currentUser,
+      });
+      return;
+    }
+
+    if (path === "auth:signOut") {
+      activeToken = null;
+      await respond(route, {});
+      return;
+    }
+
+    await respond(route, {});
+  });
+
+  return {
+    signUpCalls,
+    signInCalls,
+    validateSessionCalls,
+    getCurrentUser: () => currentUser,
+  };
+};
+
+export type { AuthUser, ConvexMocks, SetupConvexMocksOptions };


### PR DESCRIPTION
## Summary
- update the properties list E2E spec to locate header cells from the header row so the assertions work with the rendered table structure

## Testing
- pnpm lint
- pnpm typecheck
- pnpm format:check
- pnpm openapi:validate
- pnpm test
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68ddc9fff750832c9a4e6d773ac3082d